### PR TITLE
Close security token clients appropriately

### DIFF
--- a/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
@@ -18,6 +18,7 @@
 import Foundation
 import SmokeAWSCore
 import SecurityTokenClient
+import SmokeHTTPClient
 import LoggerAPI
 
 public extension SmokeAWSCore.CredentialsProvider {
@@ -28,13 +29,18 @@ public extension SmokeAWSCore.CredentialsProvider {
      - Parameters:
         - roleArn: the ARN of the role that is to be assumed.
         - roleSessionName: the session name to use when assuming the role.
+        - retryConfiguration: the client retry configuration to use to get the credentials.
+                              If not present, the default configuration will be used.
      */
-    public func getAssumedStaticCredentials(roleArn: String,
-                                            roleSessionName: String) -> StaticCredentials? {
-        let securityTokenClient = AWSSecurityTokenClient(credentialsProvider: self)
-        
-        return securityTokenClient.getAssumedStaticCredentials(roleArn: roleArn,
-                                                               roleSessionName: roleSessionName)
+    public func getAssumedStaticCredentials(
+            roleArn: String,
+            roleSessionName: String,
+            retryConfiguration: HTTPClientRetryConfiguration = .default) -> StaticCredentials? {
+        return AWSSecurityTokenClient.getAssumedStaticCredentials(
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            credentialsProvider: self,
+            retryConfiguration: retryConfiguration)
     }
     
     /**
@@ -46,14 +52,19 @@ public extension SmokeAWSCore.CredentialsProvider {
         - durationSeconds: The duration, in seconds, of the role session. The value can
             range from 900 seconds (15 minutes) to 3600 seconds (1 hour). By default, the value
             is set to 3600 seconds.
+        - retryConfiguration: the client retry configuration to use to get the credentials.
+                              If not present, the default configuration will be used.
      */
-    public func getAssumedRotatingCredentials(roleArn: String,
-                                              roleSessionName: String,
-                                              durationSeconds: Int?) -> StoppableCredentialsProvider? {
-        let securityTokenClient = AWSSecurityTokenClient(credentialsProvider: self)
-        
-        return securityTokenClient.getAssumedRotatingCredentials(roleArn: roleArn,
-                                                                 roleSessionName: roleSessionName,
-                                                                 durationSeconds: durationSeconds)
+    public func getAssumedRotatingCredentials(
+        roleArn: String,
+        roleSessionName: String,
+        durationSeconds: Int?,
+        retryConfiguration: HTTPClientRetryConfiguration = .default) -> StoppableCredentialsProvider? {
+        return AWSSecurityTokenClient.getAssumedRotatingCredentials(
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            credentialsProvider: self,
+            durationSeconds: durationSeconds,
+            retryConfiguration: retryConfiguration)
     }
 }

--- a/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
@@ -19,11 +19,45 @@ import Foundation
 import SecurityTokenClient
 import SecurityTokenModel
 import SmokeAWSCore
+import SmokeHTTPClient
 import LoggerAPI
 
 enum AssumingRoleError: Error {
     case unableToAssumeRole(arn: String, error: Error)
     case noCredentialsReturned(arn: String)
+}
+
+internal struct AWSSTSExpiringCredentialsRetriever: ExpiringCredentialsRetriever {
+    let client: AWSSecurityTokenClient
+    let roleArn: String
+    let roleSessionName: String
+    let durationSeconds: Int?
+    
+    init(credentialsProvider: CredentialsProvider,
+         roleArn: String,
+         roleSessionName: String,
+         durationSeconds: Int?,
+         retryConfiguration: HTTPClientRetryConfiguration) {
+        self.client = AWSSecurityTokenClient(credentialsProvider: credentialsProvider)
+        self.roleArn = roleArn
+        self.roleSessionName = roleSessionName
+        self.durationSeconds = durationSeconds
+    }
+    
+    func close() {
+        client.close()
+    }
+    
+    func wait() {
+        client.wait()
+    }
+    
+    func get() throws -> ExpiringCredentials {
+        return try client.getAssumedExpiringCredentials(
+                    roleArn: roleArn,
+                    roleSessionName: roleSessionName,
+                    durationSeconds: durationSeconds)
+    }
 }
 
 extension SecurityTokenClientProtocol {
@@ -66,11 +100,18 @@ extension SecurityTokenClientProtocol {
     /**
      Function that retrieves StaticCredentials from the provided token service.
      */
-    internal func getAssumedStaticCredentials(roleArn: String,
-                                              roleSessionName: String) -> StaticCredentials? {
+    internal static func getAssumedStaticCredentials(
+        roleArn: String,
+        roleSessionName: String,
+        credentialsProvider: CredentialsProvider,
+        retryConfiguration: HTTPClientRetryConfiguration) -> StaticCredentials? {
+        let securityTokenClient = AWSSecurityTokenClient(
+            credentialsProvider: credentialsProvider,
+            retryConfiguration: retryConfiguration)
+        
         let delegatedCredentials: ExpiringCredentials
         do {
-            delegatedCredentials = try getAssumedExpiringCredentials(
+            delegatedCredentials = try securityTokenClient.getAssumedExpiringCredentials(
                 roleArn: roleArn,
                 roleSessionName: roleSessionName,
                 durationSeconds: nil)
@@ -80,6 +121,8 @@ extension SecurityTokenClientProtocol {
             return nil
         }
         
+        securityTokenClient.close()
+        
         return StaticCredentials(accessKeyId: delegatedCredentials.accessKeyId,
                                  secretAccessKey: delegatedCredentials.secretAccessKey,
                                  sessionToken: delegatedCredentials.sessionToken)
@@ -88,37 +131,30 @@ extension SecurityTokenClientProtocol {
     /**
      Function that retrieves AssumedRotatingCredentials from the provided token service.
      */
-    internal func getAssumedRotatingCredentials(roleArn: String,
-                                                roleSessionName: String,
-                                                durationSeconds: Int?) -> StoppableCredentialsProvider? {
-        let delegatedCredentials: ExpiringCredentials
+    internal static func getAssumedRotatingCredentials(
+        roleArn: String,
+        roleSessionName: String,
+        credentialsProvider: CredentialsProvider,
+        durationSeconds: Int?,
+        retryConfiguration: HTTPClientRetryConfiguration) -> StoppableCredentialsProvider? {
+        let credentialsRetriever = AWSSTSExpiringCredentialsRetriever(
+            credentialsProvider: credentialsProvider,
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            durationSeconds: durationSeconds,
+            retryConfiguration: retryConfiguration)
+        
+        let delegatedRotatingCredentials: AwsRotatingCredentialsProvider
         do {
-            delegatedCredentials = try getAssumedExpiringCredentials(
-                roleArn: roleArn,
-                roleSessionName: roleSessionName,
-                durationSeconds: durationSeconds)
+            delegatedRotatingCredentials = try AwsRotatingCredentialsProvider(
+                expiringCredentialsRetriever: credentialsRetriever)
         } catch {
             Log.warning("Unable to assumed delegated rotating credentials: \(error).")
     
             return nil
         }
-        
-        let delegatedRotatingCredentials = AwsRotatingCredentialsProvider(expiringCredentials: delegatedCredentials)
     
-        // if there is an expiry
-        if let expiration = delegatedCredentials.expiration {
-            func credentialsRetriever() throws -> ExpiringCredentials {
-                return try getAssumedExpiringCredentials(
-                    roleArn: roleArn,
-                    roleSessionName: roleSessionName,
-                    durationSeconds: durationSeconds)
-            }
-            
-            delegatedRotatingCredentials.start(
-                beforeExpiration: expiration,
-                roleSessionName: roleSessionName,
-                credentialsRetriever: credentialsRetriever)
-        }
+        delegatedRotatingCredentials.start(roleSessionName: roleSessionName)
     
         return delegatedRotatingCredentials
     }

--- a/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
@@ -38,7 +38,9 @@ internal struct AWSSTSExpiringCredentialsRetriever: ExpiringCredentialsRetriever
          roleSessionName: String,
          durationSeconds: Int?,
          retryConfiguration: HTTPClientRetryConfiguration) {
-        self.client = AWSSecurityTokenClient(credentialsProvider: credentialsProvider)
+        self.client = AWSSecurityTokenClient(
+            credentialsProvider: credentialsProvider,
+            retryConfiguration: retryConfiguration)
         self.roleArn = roleArn
         self.roleSessionName = roleSessionName
         self.durationSeconds = durationSeconds


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Close AWSSecurityTokenClient when required to avoid memory leaks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
