### PR TITLE
Response handling improvements and pass in eventLoopProvider.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "9cd24ed53324785ec37fcd63d46004f606b789fd",
-          "version": "0.16.32"
+          "revision": "ecaee99e7d0aeb362328fc120423fde864727fb7",
+          "version": "0.19.7"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "fdb9c0574e3fc404763b744e808100622f3a9ded",
-          "version": "0.7.0"
+          "revision": "60bc2c4c88700ff46f2cfd1f766c4ac8319488a9",
+          "version": "0.9.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "98434c1f1d687ff5a24d2cabfbd19b5c7d2d7a2f",
-          "version": "1.13.0"
+          "revision": "29a9f2aca71c8afb07e291336f1789337ce235dd",
+          "version": "1.13.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", .upToNextMajor(from: "0.9.0")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", .upToNextMajor(from: "0.19.7")),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,14 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/amzn/smoke-aws.git", .upToNextMajor(from: "0.9.0")),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SmokeAWSCredentials",
-            dependencies: ["SecurityTokenClient", "LoggerAPI"]),
+            dependencies: ["SecurityTokenClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "LoggerAPI"]),
         .testTarget(
             name: "SmokeAWSCredentialsTests",
             dependencies: ["SmokeAWSCredentials"]),

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -18,6 +18,7 @@
 import Foundation
 import SmokeAWSCore
 import LoggerAPI
+import SmokeHTTPClient
 
 public typealias AwsContainerRotatingCredentialsProvider = AwsRotatingCredentialsProvider
 
@@ -50,13 +51,15 @@ public extension AwsContainerRotatingCredentialsProvider {
      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI key or if that key isn't present,
      static credentials under the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID keys.
      */
-    public static func get(fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment)
+    public static func get(fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
+                           eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads)
         -> StoppableCredentialsProvider? {
             let dataRetrieverProvider: (String) -> () throws -> Data = { credentialsPath in
                 return {
                     guard let response = try BasicChannelInboundHandler.call(
                         endpointHostName: credentialsHost,
                         endpointPath: credentialsPath,
+                        eventLoopProvider: eventLoopProvider,
                         endpointPort: credentialsPort) else {
                             let reason = "Unable to retrieve credentials: No credentials returned from endpoint"
                                 + " '\(credentialsHost):\(credentialsPort)/\(credentialsPath)'."

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
@@ -62,7 +62,7 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
     }
     
     private var expiringCredentials: ExpiringCredentials
-    let queue = DispatchQueue.global()
+    static let queue = DispatchQueue(label: "com.amazon.SmokeAWSCredentials.AwsRotatingCredentialsProvider")
     
     public enum Status {
         case initialized
@@ -228,7 +228,7 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
         }
         
         Log.info("\(logEntryPrefix) updated; rotation scheduled in \(hours) hours, \(minutes) minutes.")
-        queue.asyncAfter(deadline: deadline, execute: newWorker)
+        AwsRotatingCredentialsProvider.queue.asyncAfter(deadline: deadline, execute: newWorker)
         
         pthread_mutex_lock(&statusMutex)
         defer { pthread_mutex_unlock(&statusMutex) }

--- a/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
@@ -59,12 +59,14 @@ public extension SmokeAWSCore.CredentialsProvider {
         roleArn: String,
         roleSessionName: String,
         durationSeconds: Int?,
-        retryConfiguration: HTTPClientRetryConfiguration = .default) -> StoppableCredentialsProvider? {
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads) -> StoppableCredentialsProvider? {
         return AWSSecurityTokenClient.getAssumedRotatingCredentials(
             roleArn: roleArn,
             roleSessionName: roleSessionName,
             credentialsProvider: self,
             durationSeconds: durationSeconds,
-            retryConfiguration: retryConfiguration)
+            retryConfiguration: retryConfiguration,
+            eventLoopProvider: eventLoopProvider)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add the ability to pass in an eventLoopProvider when retrieving credentials and assumed credentials.
* Use a static dispatch queue for updating rotating credentials. We don't need multiple threads for credential rotation (as it is non-blocking)
* Improve handling the incoming response
* Don't use a singleton date formatter


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
