### PR TITLE
Fix for issue where spawnNewThreads option

### DIFF
--- a/Sources/SmokeAWSCredentials/BasicChannelInboundHandler.swift
+++ b/Sources/SmokeAWSCredentials/BasicChannelInboundHandler.swift
@@ -64,7 +64,12 @@ final class BasicChannelInboundHandler: ChannelInboundHandler {
         switch eventLoopProvider {
         case .spawnNewThreads:
             eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-            defer {
+        case .use(let existingEventLoopGroup):
+            eventLoopGroup = existingEventLoopGroup
+        }
+        
+        defer {
+            if case .spawnNewThreads = eventLoopProvider {
                 // shut down the event loop group when we are done
                 // (as this function will block until the request is complete)
                 do {
@@ -73,8 +78,6 @@ final class BasicChannelInboundHandler: ChannelInboundHandler {
                     Log.debug("Unable to shut down event loop group: \(error)")
                 }
             }
-        case .use(let existingEventLoopGroup):
-            eventLoopGroup = existingEventLoopGroup
         }
         
         let bootstrap = ClientBootstrap(group: eventLoopGroup)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fix for issue where spawnNewThreads option was closing the event loop group before it was being used. This would deadlock the application as it was waiting for a request on a closed event loop.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
