### PR TITLE
Keep on refreshing credentials after failure

### DIFF
--- a/Sources/SmokeAWSCredentials/ExpiringCredentials.swift
+++ b/Sources/SmokeAWSCredentials/ExpiringCredentials.swift
@@ -96,7 +96,7 @@ public struct ExpiringCredentials: Codable, SmokeAWSCore.Credentials {
                 throw SmokeAWSCredentialsError.missingCredentials(reason: reason)
         }
         
-        if let expiration = expiringCredentials.expiration, expiration.timeIntervalSinceNow < 0 {
+        if let expiration = expiringCredentials.expiration, expiration.timeIntervalSinceNow <= 0 {
             let reason = "Invalid credentials received: Expiration received that is already expired '\(expiration)'"
             throw SmokeAWSCredentialsError.missingCredentials(reason: reason)
         }

--- a/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
@@ -167,7 +167,7 @@ extension SecurityTokenClientProtocol {
     }
 }
 
-private extension String {
+internal extension String {
     /**
      Returns a date instance if this string is formatted according to
      ISO 8601 or nil otherwise. Used to schedule credential rotation.

--- a/Tests/SmokeAWSCredentialsTests/AwsContainerRotatingCredentialsTests.swift
+++ b/Tests/SmokeAWSCredentialsTests/AwsContainerRotatingCredentialsTests.swift
@@ -18,24 +18,57 @@
 import XCTest
 @testable import SmokeAWSCredentials
 
-private let data = try! jsonEncoder.encode(expiringCredentials)
+private let data1 = try! jsonEncoder.encode(expiringCredentials)
+private let data2 = try! jsonEncoder.encode(invalidCredentials1)
+private let data3 = try! jsonEncoder.encode(invalidCredentials2)
 
-private let dataRetriever: () throws -> Data = {
-    return data
+private let dataRetriever1: () throws -> Data = {
+    return data1
 }
-private let dataRetrieverProvider: (String) -> () throws -> Data = { credentialsPath in
-    return dataRetriever
+private let dataRetriever2: () throws -> Data = {
+    return data2
+}
+private let dataRetriever3: () throws -> Data = {
+    return data3
+}
+
+private let dataRetrieverProvider1: (String) -> () throws -> Data = { credentialsPath in
+    return dataRetriever1
 }
 
 class AwsContainerRotatingCredentialsTests: XCTestCase {
     func testGetCredentials() throws {
-         let credentials = try ExpiringCredentials.getCurrentCredentials(dataRetriever: dataRetriever)
+        let credentials = try ExpiringCredentials.getCurrentCredentials(dataRetriever: dataRetriever1)
         
-         XCTAssertEqual(TestVariables.accessKeyId, credentials.accessKeyId)
-         XCTAssertEqual(TestVariables.secretAccessKey, credentials.secretAccessKey)
-         XCTAssertEqual(TestVariables.sessionToken, credentials.sessionToken)
-         XCTAssertEqual(expiration, credentials.expiration!)
-     }
+        XCTAssertEqual(TestVariables.accessKeyId, credentials.accessKeyId)
+        XCTAssertEqual(TestVariables.secretAccessKey, credentials.secretAccessKey)
+        XCTAssertEqual(TestVariables.sessionToken, credentials.sessionToken)
+        XCTAssertEqual(expiration, credentials.expiration!)
+    }
+    
+    func testGetInvalidCredentials() throws {
+        do {
+            _ = try ExpiringCredentials.getCurrentCredentials(dataRetriever: dataRetriever2)
+            
+            XCTFail("Expected failure didn't occur.")
+        } catch SmokeAWSCredentialsError.missingCredentials {
+            // expected error
+        } catch {
+            XCTFail("Unexpected failure occurred: '\(error)'.")
+        }
+    }
+    
+    func testGetInvalidDateCredentials() throws {
+        do {
+            _ = try ExpiringCredentials.getCurrentCredentials(dataRetriever: dataRetriever3)
+            
+            XCTFail("Expected failure didn't occur.")
+        } catch SmokeAWSCredentialsError.missingCredentials {
+            // expected error
+        } catch {
+            XCTFail("Unexpected failure occurred: '\(error)'.")
+        }
+    }
     
     func testGetAwsContainerCredentials() {
         // don't provide an expiration to avoid setting up a rotation timer in the test
@@ -65,7 +98,7 @@ class AwsContainerRotatingCredentialsTests: XCTestCase {
                            "AWS_SECRET_ACCESS_KEY": TestVariables.secretAccessKey,
                            "AWS_SESSION_TOKEN": TestVariables.sessionToken]
         let credentialsProvider = AwsContainerRotatingCredentialsProvider.get(fromEnvironment: environment,
-                                                                                 dataRetrieverProvider: dataRetrieverProvider)!
+                                                                                 dataRetrieverProvider: dataRetrieverProvider1)!
         let credentials = credentialsProvider.credentials
         
         XCTAssertEqual(TestVariables.accessKeyId, credentials.accessKeyId)
@@ -75,13 +108,14 @@ class AwsContainerRotatingCredentialsTests: XCTestCase {
  
     func testNoCredentials() {
         let credentialsProvider = AwsContainerRotatingCredentialsProvider.get(fromEnvironment: [:],
-                                                                                 dataRetrieverProvider: dataRetrieverProvider)
+                                                                                 dataRetrieverProvider: dataRetrieverProvider1)
         
         XCTAssertNil(credentialsProvider)
     }
 
     static var allTests = [
         ("testGetCredentials", testGetCredentials),
+        ("testGetInvalidCredentials", testGetInvalidCredentials),
         ("testGetAwsContainerCredentials", testGetAwsContainerCredentials),
         ("testStaticCredentials", testStaticCredentials),
         ("testNoCredentials", testNoCredentials),

--- a/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderTests.swift
+++ b/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderTests.swift
@@ -1,0 +1,105 @@
+//
+//  AwsRotatingCredentialsProviderTests.swift
+//  SmokeAWSCredentialsTests
+//
+
+import XCTest
+@testable import SmokeAWSCredentials
+
+struct AlwaysValidRetriever: ExpiringCredentialsRetriever {
+    func close() {
+        // nothing to do
+    }
+    
+    func wait() {
+        // nothing to do
+    }
+    
+    func get() throws -> ExpiringCredentials {
+        return expiringCredentials
+    }
+}
+
+class SometimesFailRetriever: ExpiringCredentialsRetriever {
+    var invocationCount = 0;
+    var failureCount = 0;
+    
+    func close() {
+        // nothing to do
+    }
+    
+    func wait() {
+        // nothing to do
+    }
+    
+    func get() throws -> ExpiringCredentials {
+        invocationCount += 1
+        
+        guard invocationCount <= 50 else {
+            failureCount += 1
+            throw SmokeAWSCredentialsError.missingCredentials(reason: "All Wrong!")
+        }
+        
+        return expiringCredentials
+    }
+}
+
+class CountingScheduler: AsyncAfterScheduler {
+    var invocationCount = 0;
+    var doWork = true
+    
+    func asyncAfter(deadline: DispatchTime, qos: DispatchQoS,
+                    flags: DispatchWorkItemFlags,
+                    execute work: @escaping @convention(block) () -> Void) {
+        
+        // normally scheduling credentials will call asyncAfter again to schedule more credentials
+        // avoid this infinite recursion to explicitly test the scheduling functionality
+        if doWork {
+            invocationCount += 1
+            
+            doWork = false
+            work()
+        }
+    }
+}
+
+class AwsRotatingCredentialsProviderTests: XCTestCase {
+    func testAlwaysSucceedCredentialsRotation() throws {
+        let scheduler = CountingScheduler()
+        let provider = try AwsRotatingCredentialsProvider(
+            expiringCredentialsRetriever: AlwaysValidRetriever(),
+            scheduler: scheduler)
+        
+        // simulate 100 successful credentials
+        for _ in 0..<100 {
+            let beforeExpiration = Date(timeIntervalSinceNow: 60)
+            
+            provider.scheduleUpdateCredentials(beforeExpiration: beforeExpiration,
+                                               roleSessionName: "roleSessionName")
+            // make sure we schedule the credentials once per invocation
+            scheduler.doWork = true
+        }
+        
+        XCTAssertEqual(100, scheduler.invocationCount)
+    }
+    
+    func testSometimesFailCredentialsRotation() throws {
+        let scheduler = CountingScheduler()
+        let retriever = SometimesFailRetriever()
+        let provider = try AwsRotatingCredentialsProvider(
+            expiringCredentialsRetriever: retriever,
+            scheduler: scheduler)
+        
+        for _ in 0..<100 {
+            let beforeExpiration = Date(timeIntervalSinceNow: 60)
+            
+            provider.scheduleUpdateCredentials(beforeExpiration: beforeExpiration,
+                                               roleSessionName: "roleSessionName")
+            // make sure we schedule the credentials once per invocation
+            scheduler.doWork = true
+        }
+        
+        XCTAssertEqual(100, scheduler.invocationCount)
+        XCTAssertEqual(50, retriever.failureCount)
+    }
+}

--- a/Tests/SmokeAWSCredentialsTests/TestConfiguration.swift
+++ b/Tests/SmokeAWSCredentialsTests/TestConfiguration.swift
@@ -36,12 +36,23 @@ struct TestVariables {
     static let assumedRoleId = "assumedRoleId"
     static let accessKeyId = "accessKeyId"
     static let expiration = "4118-03-12T20:29:09Z"
+    static let pastExpiration = "1918-03-12T20:29:09Z"
     static let secretAccessKey = "secretAccessKey"
     static let sessionToken = "sessionToken"
+    static let nullString = "null"
 }
 
 let expiration = TestVariables.expiration.dateFromISO8601String!
+let pastExpiration = TestVariables.pastExpiration.dateFromISO8601String!
 let expiringCredentials = ExpiringCredentials(accessKeyId: TestVariables.accessKeyId,
                                               expiration: expiration,
+                                              secretAccessKey: TestVariables.secretAccessKey,
+                                              sessionToken: TestVariables.sessionToken)
+let invalidCredentials1 = ExpiringCredentials(accessKeyId: TestVariables.nullString,
+                                              expiration: expiration,
+                                              secretAccessKey: TestVariables.nullString,
+                                              sessionToken: TestVariables.nullString)
+let invalidCredentials2 = ExpiringCredentials(accessKeyId: TestVariables.accessKeyId,
+                                              expiration: pastExpiration,
                                               secretAccessKey: TestVariables.secretAccessKey,
                                               sessionToken: TestVariables.sessionToken)

--- a/Tests/SmokeAWSCredentialsTests/TestConfiguration.swift
+++ b/Tests/SmokeAWSCredentialsTests/TestConfiguration.swift
@@ -35,12 +35,12 @@ struct TestVariables {
     static let arn = "ARN"
     static let assumedRoleId = "assumedRoleId"
     static let accessKeyId = "accessKeyId"
-    static let expiration = "2118-03-12T20:29:09Z"
+    static let expiration = "4118-03-12T20:29:09Z"
     static let secretAccessKey = "secretAccessKey"
     static let sessionToken = "sessionToken"
 }
 
-let expiration = Date(timeIntervalSince1970: 1522283216)
+let expiration = TestVariables.expiration.dateFromISO8601String!
 let expiringCredentials = ExpiringCredentials(accessKeyId: TestVariables.accessKeyId,
                                               expiration: expiration,
                                               secretAccessKey: TestVariables.secretAccessKey,


### PR DESCRIPTION
*Issue #, if available:* #7 and #8 

*Description of changes:* Continue to refresh credentials in the future if an refresh attempt fails to avoid never regaining valid credentials in the future. Avoid attempting to use junk credentials.

*Testing performed:* Added unit tests to verify these additions. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
