### PR TITLE
Add CI Tests for Swift 5.0 and 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 /.build
 /Packages
+.swiftpm/
 /*.xcodeproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
       ervices: docker
       env: DOCKER_IMAGE_TAG=swift:4.2.1 USE_SWIFT_LINT=yes
     - os: linux

--- a/CITests/run
+++ b/CITests/run
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-swiftLintVersion=0.29.0
+swiftLintVersion=0.33.0
 
 USE_SWIFT_LINT=$1
+
+apt-get update
+apt-get -y install libssl-dev libz-dev
 
 workspaceRoot=($PWD)
 srcRoot=$workspaceRoot/sources

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "95c51bcf7f1cf477eedb73a03e2e1d5fb4f4f028",
-          "version": "1.20.3"
+          "revision": "36a4d11942ed209129427185c25dabb03007eb92",
+          "version": "1.25.3"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {
           "branch": null,
-          "revision": "e29073bb7cecf3673e56bcb16180e8fd0cb091f6",
-          "version": "1.8.1"
+          "revision": "3357dd9526cdf9436fa63bb792b669e6efdc43da",
+          "version": "1.9.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "c868898a601a2e7484377ba18b18fa215719cef9",
-          "version": "1.19.9"
+          "revision": "95c51bcf7f1cf477eedb73a03e2e1d5fb4f4f028",
+          "version": "1.20.3"
         }
       },
       {
@@ -24,8 +24,17 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "60bc2c4c88700ff46f2cfd1f766c4ac8319488a9",
-          "version": "1.0.0"
+          "revision": "705553c6f59d15f8b9fe2fd458a0ad3755ef9bc4",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "eba9b323b5ba542c119ff17382a4ce737bcdc0b8",
+          "version": "0.0.0"
         }
       },
       {
@@ -33,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "29a9f2aca71c8afb07e291336f1789337ce235dd",
-          "version": "1.13.2"
+          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
+          "version": "1.14.1"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/LiveUI/XMLCoding.git",
         "state": {
           "branch": null,
-          "revision": "8c760e960a5e53a5338c2871c4fcdf06b8c5ace4",
-          "version": "0.4.0"
+          "revision": "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
+          "version": "0.4.1"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-4.2-orange.svg?style=flat" alt="Swift 4.1 Compatible">
 </a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
+</a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Compatible">
+</a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -144,14 +144,22 @@ public extension AwsContainerRotatingCredentialsProvider {
             let outputPipe = Pipe()
             
             let task = Process()
+            #if os(Linux) && (swift(>=5.0) || (swift(>=4.1.50) && !swift(>=4.2)) || (swift(>=3.5) && !swift(>=4.0)))
+            task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            #else
             task.launchPath = "/usr/bin/env"
+            #endif
             task.arguments = ["/usr/local/bin/get-credentials.sh",
                               "-r",
                               iamRoleArn,
                               "-d",
                               "900"]
             task.standardOutput = outputPipe
+            #if os(Linux) && (swift(>=5.0) || (swift(>=4.1.50) && !swift(>=4.2)) || (swift(>=3.5) && !swift(>=4.0)))
+            task.run()
+            #else
             task.launch()
+            #endif
             task.waitUntilExit()
 
             return outputPipe.fileHandleForReading.availableData

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -155,8 +155,8 @@ public extension AwsContainerRotatingCredentialsProvider {
                               "-d",
                               "900"]
             task.standardOutput = outputPipe
-            #if os(Linux) && (swift(>=5.0) || (swift(>=4.1.50) && !swift(>=4.2)) || (swift(>=3.5) && !swift(>=4.0)))
-            task.run()
+            #if os(Linux) && swift(>=5.0)
+            try task.run()
             #else
             task.launch()
             #endif

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -43,7 +43,7 @@ public extension AwsContainerRotatingCredentialsProvider {
      This script should write to its standard output a JSON structure capable of
      being decoded into the ExpiringCredentials structure.
      */
-    public static let devIamRoleArnEnvironmentVariable = "DEV_CREDENTIALS_IAM_ROLE_ARN"
+    static let devIamRoleArnEnvironmentVariable = "DEV_CREDENTIALS_IAM_ROLE_ARN"
  
     /**
      Static function that retrieves credentials provider from the specified environment -
@@ -51,7 +51,7 @@ public extension AwsContainerRotatingCredentialsProvider {
      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI key or if that key isn't present,
      static credentials under the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID keys.
      */
-    public static func get(fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
+    static func get(fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
                            eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads)
         -> StoppableCredentialsProvider? {
             let dataRetrieverProvider: (String) -> () throws -> Data = { credentialsPath in

--- a/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
@@ -32,7 +32,7 @@ public extension SmokeAWSCore.CredentialsProvider {
         - retryConfiguration: the client retry configuration to use to get the credentials.
                               If not present, the default configuration will be used.
      */
-    public func getAssumedStaticCredentials(
+    func getAssumedStaticCredentials(
             roleArn: String,
             roleSessionName: String,
             retryConfiguration: HTTPClientRetryConfiguration = .default) -> StaticCredentials? {
@@ -55,7 +55,7 @@ public extension SmokeAWSCore.CredentialsProvider {
         - retryConfiguration: the client retry configuration to use to get the credentials.
                               If not present, the default configuration will be used.
      */
-    public func getAssumedRotatingCredentials(
+    func getAssumedRotatingCredentials(
         roleArn: String,
         roleSessionName: String,
         durationSeconds: Int?,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add CI tests for Swift 5.0 and Swift 5.1
2. Fix compile warnings under Swift 5.x


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
