### PR TITLE
Replace SmokeAWSInvocationReporting protocol

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "1b470aa52fb87b0db6805e7cca9a1264548a60e4",
-          "version": "2.0.0-alpha.3"
+          "revision": "46d969a9b27fe8ee48035fe615282654125355cf",
+          "version": "2.0.0-alpha.4"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "705a512220e9308c3268e85ea4db8535b54294eb",
-          "version": "2.0.0-alpha.4"
+          "revision": "da6596f8602cc293a1d026f0c0dac3bd39e78ab0",
+          "version": "2.0.0-alpha.6"
         }
       },
       {
@@ -39,11 +39,11 @@
       },
       {
         "package": "swift-metrics",
-        "repositoryURL": "https://github.com/apple/swift-metrics",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "09b72f68ed9b01b614c12855fc7e22876b97a97e",
-          "version": "1.2.1"
+          "revision": "708b960b4605abb20bc55d65abf6bad607252200",
+          "version": "2.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.4"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -51,7 +51,7 @@ public extension AwsContainerRotatingCredentialsProvider {
      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI key or if that key isn't present,
      static credentials under the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID keys.
      */
-    static func get<InvocationReportingType: SmokeAWSInvocationReporting>(
+    static func get<InvocationReportingType: HTTPClientCoreInvocationReporting>(
             fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
             reporting: InvocationReportingType,
             eventLoopProvider: HTTPClient.EventLoopProvider = .spawnNewThreads)
@@ -81,7 +81,7 @@ public extension AwsContainerRotatingCredentialsProvider {
     /**
      Internal static function for testing.
      */
-    static func get<InvocationReportingType: SmokeAWSInvocationReporting>(
+    static func get<InvocationReportingType: HTTPClientCoreInvocationReporting>(
             fromEnvironment environment: [String: String],
             reporting: InvocationReportingType,
             dataRetrieverProvider: (String) -> () throws -> Data)
@@ -114,7 +114,7 @@ public extension AwsContainerRotatingCredentialsProvider {
             return credentialsProvider
     }
     
-    private static func getStaticCredentialsProvider<InvocationReportingType: SmokeAWSInvocationReporting>(
+    private static func getStaticCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         fromEnvironment environment: [String: String],
         reporting: InvocationReportingType,
         dataRetrieverProvider: (String) -> () throws -> Data)
@@ -141,7 +141,7 @@ public extension AwsContainerRotatingCredentialsProvider {
     }
     
 #if DEBUG
-    private static func getDevRotatingCredentialsProvider<InvocationReportingType: SmokeAWSInvocationReporting>(
+    private static func getDevRotatingCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
             fromEnvironment environment: [String: String],
             reporting: InvocationReportingType) -> StoppableCredentialsProvider? {
         // get the values of the environment variables
@@ -195,7 +195,7 @@ public extension AwsContainerRotatingCredentialsProvider {
     }
 #endif
     
-    private static func getRotatingCredentialsProvider<InvocationReportingType: SmokeAWSInvocationReporting>(
+    private static func getRotatingCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         fromEnvironment environment: [String: String],
         reporting: InvocationReportingType,
         dataRetrieverProvider: (String) -> () throws -> Data)
@@ -227,7 +227,7 @@ public extension AwsContainerRotatingCredentialsProvider {
         return rotatingCredentialsProvider
     }
     
-    private static func createRotatingCredentialsProvider<InvocationReportingType: SmokeAWSInvocationReporting>(
+    private static func createRotatingCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         reporting: InvocationReportingType,
         dataRetriever: @escaping () throws -> Data) throws
         -> StoppableCredentialsProvider {

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+import SmokeHTTPClient
 import SmokeAWSCore
 import Logging
 
@@ -132,7 +133,7 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
     /**
      Schedules credentials rotation to begin.
      */
-    public func start<InvocationReportingType: SmokeAWSInvocationReporting>(
+    public func start<InvocationReportingType: HTTPClientCoreInvocationReporting>(
             roleSessionName: String?,
             reporting: InvocationReportingType) {
         guard case .initialized = status else {
@@ -208,7 +209,7 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
         return true
     }
     
-    internal func scheduleUpdateCredentials<InvocationReportingType: SmokeAWSInvocationReporting>(
+    internal func scheduleUpdateCredentials<InvocationReportingType: HTTPClientCoreInvocationReporting>(
             beforeExpiration expiration: Date,
             roleSessionName: String?,
             reporting: InvocationReportingType) {

--- a/Sources/SmokeAWSCredentials/BasicChannelInboundHandler.swift
+++ b/Sources/SmokeAWSCredentials/BasicChannelInboundHandler.swift
@@ -33,7 +33,7 @@ enum BasicHttpChannelError: Error {
  A basic ChannelInboundHandler for contacting an endpoint and
  returning the response as a Data instance.
  */
-final class BasicChannelInboundHandler<InvocationReportingType: SmokeAWSInvocationReporting>: ChannelInboundHandler {
+final class BasicChannelInboundHandler<InvocationReportingType: HTTPClientCoreInvocationReporting>: ChannelInboundHandler {
     public typealias InboundIn = HTTPClientResponsePart
     public typealias OutboundOut = HTTPClientRequestPart
     

--- a/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
@@ -32,7 +32,7 @@ public extension SmokeAWSCore.CredentialsProvider {
         - retryConfiguration: the client retry configuration to use to get the credentials.
                               If not present, the default configuration will be used.
      */
-    func getAssumedStaticCredentials<InvocationReportingType: SmokeAWSInvocationReporting>(
+    func getAssumedStaticCredentials<InvocationReportingType: HTTPClientCoreInvocationReporting>(
             roleArn: String,
             roleSessionName: String,
             reporting: InvocationReportingType,
@@ -57,7 +57,7 @@ public extension SmokeAWSCore.CredentialsProvider {
         - retryConfiguration: the client retry configuration to use to get the credentials.
                               If not present, the default configuration will be used.
      */
-    func getAssumedRotatingCredentials<InvocationReportingType: SmokeAWSInvocationReporting>(
+    func getAssumedRotatingCredentials<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         roleArn: String,
         roleSessionName: String,
         durationSeconds: Int?,

--- a/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
@@ -27,7 +27,7 @@ enum AssumingRoleError: Error {
     case noCredentialsReturned(arn: String)
 }
 
-internal struct AWSSTSExpiringCredentialsRetriever<InvocationReportingType: SmokeAWSInvocationReporting>: ExpiringCredentialsRetriever {
+internal struct AWSSTSExpiringCredentialsRetriever<InvocationReportingType: HTTPClientCoreInvocationReporting>: ExpiringCredentialsRetriever {
     let client: AWSSecurityTokenClient<InvocationReportingType>
     let roleArn: String
     let roleSessionName: String
@@ -106,7 +106,7 @@ extension SecurityTokenClientProtocol {
     /**
      Function that retrieves StaticCredentials from the provided token service.
      */
-    internal static func getAssumedStaticCredentials<InvocationReportingType: SmokeAWSInvocationReporting>(
+    internal static func getAssumedStaticCredentials<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         roleArn: String,
         roleSessionName: String,
         credentialsProvider: CredentialsProvider,
@@ -140,7 +140,7 @@ extension SecurityTokenClientProtocol {
     /**
      Function that retrieves AssumedRotatingCredentials from the provided token service.
      */
-    internal static func getAssumedRotatingCredentials<InvocationReportingType: SmokeAWSInvocationReporting>(
+    internal static func getAssumedRotatingCredentials<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         roleArn: String,
         roleSessionName: String,
         credentialsProvider: CredentialsProvider,

--- a/Tests/SmokeAWSCredentialsTests/AwsContainerRotatingCredentialsTests.swift
+++ b/Tests/SmokeAWSCredentialsTests/AwsContainerRotatingCredentialsTests.swift
@@ -17,8 +17,7 @@
 
 import XCTest
 @testable import SmokeAWSCredentials
-import SmokeAWSHttp
-import SmokeAWSCore
+import SmokeHTTPClient
 
 private let data1 = try! jsonEncoder.encode(expiringCredentials)
 private let data2 = try! jsonEncoder.encode(invalidCredentials1)
@@ -88,7 +87,7 @@ class AwsContainerRotatingCredentialsTests: XCTestCase {
         let environment = ["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "endpoint"]
         let credentialsProvider = AwsContainerRotatingCredentialsProvider.get(
             fromEnvironment: environment,
-            reporting: MockInvocationReporting(),
+            reporting: MockCoreInvocationReporting(),
             dataRetrieverProvider: dataRetrieverProvider)!
         let credentials = credentialsProvider.credentials
         
@@ -103,7 +102,7 @@ class AwsContainerRotatingCredentialsTests: XCTestCase {
                            "AWS_SESSION_TOKEN": TestVariables.sessionToken]
         let credentialsProvider = AwsContainerRotatingCredentialsProvider.get(
             fromEnvironment: environment,
-            reporting: MockInvocationReporting(),
+            reporting: MockCoreInvocationReporting(),
             dataRetrieverProvider: dataRetrieverProvider1)!
         let credentials = credentialsProvider.credentials
         
@@ -115,7 +114,7 @@ class AwsContainerRotatingCredentialsTests: XCTestCase {
     func testNoCredentials() {
         let credentialsProvider = AwsContainerRotatingCredentialsProvider.get(
             fromEnvironment: [:],
-            reporting: MockInvocationReporting(),
+            reporting: MockCoreInvocationReporting(),
             dataRetrieverProvider: dataRetrieverProvider1)
         
         XCTAssertNil(credentialsProvider)

--- a/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderTests.swift
+++ b/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderTests.swift
@@ -5,7 +5,7 @@
 
 import XCTest
 @testable import SmokeAWSCredentials
-import SmokeAWSCore
+import SmokeHTTPClient
 
 struct AlwaysValidRetriever: ExpiringCredentialsRetriever {
     func close() {
@@ -77,7 +77,7 @@ class AwsRotatingCredentialsProviderTests: XCTestCase {
             
             provider.scheduleUpdateCredentials(beforeExpiration: beforeExpiration,
                                                roleSessionName: "roleSessionName",
-                                               reporting: MockInvocationReporting())
+                                               reporting: MockCoreInvocationReporting())
             // make sure we schedule the credentials once per invocation
             scheduler.doWork = true
         }
@@ -97,7 +97,7 @@ class AwsRotatingCredentialsProviderTests: XCTestCase {
             
             provider.scheduleUpdateCredentials(beforeExpiration: beforeExpiration,
                                                roleSessionName: "roleSessionName",
-                                               reporting: MockInvocationReporting())
+                                               reporting: MockCoreInvocationReporting())
             // make sure we schedule the credentials once per invocation
             scheduler.doWork = true
         }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Replace SmokeAWSInvocationReporting protocol with HTTPClientCoreInvocationReporting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
