### PR TITLE
Use swift crypto when compiling with Swift 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.2-bionic USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.2-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,16 +6,16 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "e2636a4c24e646d3e480fc666da0c090818beb09",
-          "version": "1.1.0"
+          "revision": "037b70291941fe43de668066eb6fb802c5e181d2",
+          "version": "1.1.1"
         }
       },
       {
-        "package": "SmokeAWS",
+        "package": "smoke-aws",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": "use_swift_crypto_under_5_2",
-          "revision": "4d8b63cccc78bad8ad3ed270fca7632989b39ba7",
+          "revision": "6d82ff38cb9d54679340ded9aa55af47d9e784a9",
           "version": null
         }
       },
@@ -38,6 +38,15 @@
         }
       },
       {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
+          "version": "1.2.0"
+        }
+      },
+      {
         "package": "swift-metrics",
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
@@ -51,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
-          "version": "2.14.0"
+          "revision": "e876fb37410e0036b98b5361bb18e6854739572b",
+          "version": "2.16.0"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "af46d9b58fafbb76f9b01177568d435a1b024f99",
-          "version": "2.6.2"
+          "revision": "ae213938e151964aa691f0e902462fbe06baeeb6",
+          "version": "2.7.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,12 @@
         }
       },
       {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "12d2bf3ec7207ec3cd004b9582f69ef5fae1da3b",
-          "version": "1.0.32"
-        }
-      },
-      {
         "package": "SmokeAWS",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
-          "branch": null,
-          "revision": "bbc082c45f69fb44d190e9b377520737cd16f1f8",
-          "version": "2.0.0-alpha.5"
+          "branch": "use_swift_crypto_under_5_2",
+          "revision": "4d8b63cccc78bad8ad3ed270fca7632989b39ba7",
+          "version": null
         }
       },
       {
@@ -33,17 +24,17 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "ae8003b3605c0b368925558254055222237b1da4",
-          "version": "2.0.0-alpha.7"
+          "revision": "e61b72adebfb054204dc3c3c122a27072cb04d05",
+          "version": "2.0.0-alpha.8"
         }
       },
       {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
-          "version": "1.2.0"
+          "revision": "d67ac68d09a95443303e9d6e37b34e7ba101d5f1",
+          "version": "1.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,18 +14,18 @@
         "package": "smoke-aws",
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
-          "branch": "use_swift_crypto_under_5_2",
-          "revision": "6d82ff38cb9d54679340ded9aa55af47d9e784a9",
-          "version": null
+          "branch": null,
+          "revision": "747aa0495274a51597c55c158520cfca6788a601",
+          "version": "2.0.0-alpha.6"
         }
       },
       {
-        "package": "SmokeHTTP",
+        "package": "smoke-http",
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "e61b72adebfb054204dc3c3c122a27072cb04d05",
-          "version": "2.0.0-alpha.8"
+          "revision": "a3fd185135fe2fc40ef609983071d44dafce36f1",
+          "version": "2.0.0-alpha.9"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "747aa0495274a51597c55c158520cfca6788a601",
-          "version": "2.0.0-alpha.6"
+          "revision": "160eb9f262bedaef44713eabb9d6c24cbc334d84",
+          "version": "2.0.0-beta.1"
         }
       },
       {
@@ -25,7 +25,7 @@
         "state": {
           "branch": null,
           "revision": "a3fd185135fe2fc40ef609983071d44dafce36f1",
-          "version": "2.0.0-alpha.9"
+          "version": "2.0.0-beta.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "SmokeAWSCredentials",
+    name: "smoke-aws-credentials",
     platforms: [
         .macOS(.v10_15), .iOS(.v10)
         ],
@@ -26,14 +26,14 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(name: "SmokeAWS", url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "SmokeAWSCredentials", dependencies: [
-                .product(name: "SecurityTokenClient", package: "SmokeAWS"),
+                .product(name: "SecurityTokenClient", package: "smoke-aws"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.6"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.6"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.0
 //
 // Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "SmokeAWSCredentials",
     platforms: [
-        .macOS(.v10_15), .iOS(.v10)
+        .macOS(.v10_12), .iOS(.v10)
         ],
     products: [
         .library(
@@ -26,23 +26,17 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(name: "SmokeAWS", url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .target(
-            name: "SmokeAWSCredentials", dependencies: [
-                .product(name: "SecurityTokenClient", package: "SmokeAWS"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIO", package: "swift-nio"),
-                .product(name: "NIOHTTP1", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio"),
-            ]),
+            name: "SmokeAWSCredentials",
+            dependencies: ["SecurityTokenClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "Logging"]),
         .testTarget(
-            name: "SmokeAWSCredentialsTests", dependencies: [
-                .target(name: "SmokeAWSCredentials"),
-            ]),
+            name: "SmokeAWSCredentialsTests",
+            dependencies: ["SmokeAWSCredentials"]),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.0
 //
 // Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "SmokeAWSCredentials",
     platforms: [
-        .macOS(.v10_15), .iOS(.v10)
+        .macOS(.v10_12), .iOS(.v10)
         ],
     products: [
         .library(
@@ -26,23 +26,17 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(name: "SmokeAWS", url: "https://github.com/amzn/smoke-aws.git", .branch("use_swift_crypto_under_5_2")),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .target(
-            name: "SmokeAWSCredentials", dependencies: [
-                .product(name: "SecurityTokenClient", package: "SmokeAWS"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIO", package: "swift-nio"),
-                .product(name: "NIOHTTP1", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio"),
-            ]),
+            name: "SmokeAWSCredentials",
+            dependencies: ["SecurityTokenClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "Logging"]),
         .testTarget(
-            name: "SmokeAWSCredentialsTests", dependencies: [
-                .target(name: "SmokeAWSCredentials"),
-            ]),
+            name: "SmokeAWSCredentialsTests",
+            dependencies: ["SmokeAWSCredentials"]),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-alpha.5"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Compatible">
 </a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.2-orange.svg?style=flat" alt="Swift 5.2 Compatible">
+</a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import SmokeAWSCore
+import SmokeAWSHttp
 import Logging
 import SmokeHTTPClient
 import AsyncHTTPClient
@@ -65,6 +66,23 @@ public extension AwsContainerRotatingCredentialsProvider {
      being decoded into the ExpiringCredentials structure.
      */
     static let devIamRoleArnEnvironmentVariable = "DEV_CREDENTIALS_IAM_ROLE_ARN"
+    
+    /**
+     Static function that retrieves credentials provider from the specified environment -
+     either rotating credentials retrieved from an endpoint specified under the
+     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI key or if that key isn't present,
+     static credentials under the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID keys.
+     */
+    static func get(
+            fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
+            logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+            eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew)
+        -> StoppableCredentialsProvider? {
+            return get(fromEnvironment: environment,
+                       logger: logger,
+                       traceContext: AWSClientInvocationTraceContext(),
+                       eventLoopProvider: eventLoopProvider)
+    }
  
     /**
      Static function that retrieves credentials provider from the specified environment -
@@ -74,7 +92,7 @@ public extension AwsContainerRotatingCredentialsProvider {
      */
     static func get<TraceContextType: InvocationTraceContext>(
             fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
-            logger: Logging.Logger,
+            logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
             traceContext: TraceContextType,
             eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew)
         -> StoppableCredentialsProvider? {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add Swift 5.2 CI tests.
2. Update tools version to 5.2.
3. Add legacy manifest files for Swift 5.0 and 5.1.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
