### PR TITLE
Close credentials retriever as soon as possible.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8ccba7328d178ac05a1a9803cf3f2c6660d2f826",
-          "version": "1.3.0"
+          "revision": "8e4d51908dd49272667126403bf977c5c503f78f",
+          "version": "1.5.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "393ed524ef10d64e6e8d501297c61447c4f32155",
-          "version": "2.38.43"
+          "revision": "770dfceb85a41e1c645a8b674832e5560a2147a7",
+          "version": "2.39.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "3fb6de3124df1857cb9f12aacc963b96c83e407a",
-          "version": "2.8.3"
+          "revision": "0f0ac49e96208b709a58a5e5d59d05bab44957aa",
+          "version": "2.8.5"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d161bf658780b209c185994528e7e24376cf7283",
-          "version": "2.29.0"
+          "revision": "9a992ee3de1f8da9f2968fc96b26714834f3105f",
+          "version": "2.31.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
-          "version": "1.8.0"
+          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
+          "version": "1.10.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "6363cdf6d2fb863e82434f3c4618f4e896e37569",
-          "version": "2.13.1"
+          "revision": "9db7cee4b62c39160a6bd513a47a1ecdcceac18a",
+          "version": "2.14.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "657537c2cf1845f8d5201ecc4e48f21f21841128",
-          "version": "1.10.0"
+          "revision": "39587bceccda72780e2a8a8c5e857e42a9df2fa8",
+          "version": "1.11.0"
         }
       },
       {

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
@@ -160,6 +160,7 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
             completedSemaphore.signal()
         case .running:
             status = .shuttingDown
+            try expiringCredentialsRetriever.close()
         default:
             // nothing to do
             break
@@ -195,7 +196,6 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
         
         guard case .running = status else {
             status = .stopped
-            try? expiringCredentialsRetriever.close()
             completedSemaphore.signal()
             return false
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Close credentials retriever as soon as possible. Prevents issues when shutdown occurs before the next credentials refresh.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
