### PR TITLE
Support for async credentials shutdown.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "170fd536f931c0bffb58f37a53fc238e77f42258",
-          "version": "1.6.4"
+          "revision": "cbf533073d9a5edfb16c266d14151f69137ba7c9",
+          "version": "1.8.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-aws.git",
         "state": {
           "branch": null,
-          "revision": "40e61c4e055e91bb36ac8f82d2ddfc80fd1dbb17",
-          "version": "2.41.17"
+          "revision": "3181f04b53977676581a30977c104d45daa8de06",
+          "version": "2.42.37"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/amzn/smoke-http.git",
         "state": {
           "branch": null,
-          "revision": "cc2ca1f0d64cfd0f543b23b4f1a95329943ed22c",
-          "version": "2.10.0"
+          "revision": "6100bbea63e759b6a23e9e43bd08ded034dbeec0",
+          "version": "2.12.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "addf69cfe60376c325397c8926589415576b1dd1",
-          "version": "2.34.0"
+          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
+          "version": "2.37.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "326f7f9a8c8c8402e3691adac04911cac9f9d87f",
-          "version": "1.18.4"
+          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
+          "version": "1.19.1"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "36f6419f2b1b6490a8c0faa840298e28027cefe9",
-          "version": "2.16.3"
+          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
+          "version": "2.17.2"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
-          "version": "1.11.3"
+          "revision": "8ab824b140d0ebcd87e9149266ddc353e3705a3e",
+          "version": "1.11.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["SmokeAWSCredentials"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.0.0"),
+        .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.42.37"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],

--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ The credentials returned will be valid for at least *5 minutes* from the time th
 When you no longer need these credentials, you can stop the background credentials rotation.
 
 ```swift
-    credentialsProvider.stop()
+    try await credentialsProvider.shutdown()
+```
+
+OR
+
+```swift
+    try credentialsProvider.syncShutdown()
 ```
 
 ## Step 3: Assuming credentials using existing credentials

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -350,6 +350,12 @@ public extension AwsContainerRotatingCredentialsProvider {
             // nothing to do
         }
         
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+        func shutdown() async throws {
+            // nothing to do
+        }
+#endif
+        
         func wait() {
             // nothing to do
         }

--- a/Sources/SmokeAWSCredentials/StoppableCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/StoppableCredentialsProvider.swift
@@ -28,7 +28,27 @@ public protocol StoppableCredentialsProvider: CredentialsProvider {
      Gracefully shuts down background management of these
      credentials. May block until ongoing work completes.
      */
+    func syncShutdown() throws
+    
+    @available(*, deprecated, renamed: "syncShutdown")
     func stop() throws
+    
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    func shutdown() async throws
+#endif
+}
+
+public extension StoppableCredentialsProvider {
+    @available(swift, deprecated: 3.0, message: "To avoid a breaking change, by default syncShutdown() delegates to the implementation of stop()")
+    func syncShutdown() throws {
+        try stop()
+    }
+    
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    func shutdown() async throws {
+        fatalError("`shutdown() async throws` needs to be implemented on `StoppableCredentialsProvider` conforming type to allow for async shutdown.")
+    }
+#endif
 }
 
 /**
@@ -39,4 +59,10 @@ extension SmokeAWSCore.StaticCredentials: StoppableCredentialsProvider {
     public func stop() throws {
         // nothing to do
     }
+    
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+    public func shutdown() async throws {
+        // nothing to do
+    }
+#endif
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
1. Add async shutdown method for `StoppableCredentialsProvider`. 
2. Add a `syncShutdown` method for `StoppableCredentialsProvider` and deprecate the existing `close` method for clarity and consistency.

This is not a breaking change; the additional methods on the `StoppableCredentialsProvider` protocol have default implementations. The async shutdown method default implementation will fatal error; conforming types outside of this package will need to override this implementation if they want to move to using async shutdown. The conforming types in this package override the default implementation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
