### PR TITLE
Swift Concurrency refactor.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,11 +11,11 @@ jobs:
     name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04]
-        swift: ["5.6.1"]
+        os: [ubuntu-22.04, ubuntu-20.04]
+        swift: ["5.7.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.15.0
+      - uses: swift-actions/setup-swift@v1.22.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.5.3", "5.4.3"]
+        swift: ["5.6.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.15.0
+      - uses: swift-actions/setup-swift@v1.22.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.7.3"]
+        swift: ["5.8"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.22.0
+      - uses: swift-actions/setup-swift@v1.23.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.6.3"]
+        swift: ["5.7.3", "5.6.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.22.0
+      - uses: swift-actions/setup-swift@v1.23.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-aws-credentials/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.4|5.5|5.6-orange.svg?style=flat" alt="Swift 5.4, 5.5 and 5.6 Tested">
+<img src="https://img.shields.io/badge/swift-5.6|5.7-orange.svg?style=flat" alt="Swift 5.6, 5.7 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 <img src="https://github.com/amzn/smoke-aws-credentials/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.6|5.7-orange.svg?style=flat" alt="Swift 5.6, 5.7 Tested">
+<img src="https://img.shields.io/badge/swift-5.6|5.7|5.8-orange.svg?style=flat" alt="Swift 5.6, 5.7 and 5.8 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
-<img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">
-<img src="https://img.shields.io/badge/AmazonLinux-2-yellow.svg?style=flat" alt="Amazon Linux 2 Tested">
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>

--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -23,6 +23,14 @@ import SmokeHTTPClient
 import AsyncHTTPClient
 import NIOHTTP1
 
+internal protocol ContainerExpiringCredentialsRetrieverProtocol: ExpiringCredentialsRetrieverV2 {
+    init(eventLoopProvider: HTTPClient.EventLoopGroupProvider, credentialsPath: String, logger: Logger)
+}
+
+internal protocol DevExpiringCredentialsRetrieverProtocol: ExpiringCredentialsRetrieverV2 {
+    init(iamRoleArn: String)
+}
+
 internal struct CredentialsInvocationReporting<TraceContextType: InvocationTraceContext>: HTTPClientCoreInvocationReporting {
     public let logger: Logger
     public var internalRequestId: String
@@ -35,7 +43,10 @@ internal struct CredentialsInvocationReporting<TraceContextType: InvocationTrace
     }
 }
 
+@available(*, deprecated, renamed: "AwsContainerRotatingCredentialsProviderV2")
 public typealias AwsContainerRotatingCredentialsProvider = AwsRotatingCredentialsProvider
+
+public typealias AwsContainerRotatingCredentialsProviderV2 = AwsRotatingCredentialsProviderV2
 
 enum CredentialsHTTPError: Error {
     case invalidEndpoint(String)
@@ -44,6 +55,7 @@ enum CredentialsHTTPError: Error {
     case noResponse
 }
 
+@available(*, deprecated, renamed: "AwsContainerRotatingCredentialsProviderV2")
 public extension AwsContainerRotatingCredentialsProvider {
     // the endpoint for obtaining credentials from the ECS container
     // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
@@ -74,145 +86,54 @@ public extension AwsContainerRotatingCredentialsProvider {
      static credentials under the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID keys.
      */
     static func get(
-            fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
-            logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
-            eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew)
-        -> StoppableCredentialsProvider? {
-            return get(fromEnvironment: environment,
-                       logger: logger,
-                       traceContext: AWSClientInvocationTraceContext(),
-                       eventLoopProvider: eventLoopProvider)
-    }
- 
-    /**
-     Static function that retrieves credentials provider from the specified environment -
-     either rotating credentials retrieved from an endpoint specified under the
-     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI key or if that key isn't present,
-     static credentials under the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID keys.
-     */
-    static func get<TraceContextType: InvocationTraceContext>(
-            fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
-            logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
-            traceContext: TraceContextType,
-            eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew)
-        -> StoppableCredentialsProvider? {
-            var credentialsLogger = logger
-            credentialsLogger[metadataKey: "credentials.source"] = "environment"
-            let reporting = CredentialsInvocationReporting(logger: credentialsLogger,
-                                                           internalRequestId: "credentials.environment",
-                                                           traceContext: traceContext)
-            
-            let dataRetrieverProvider: (String) -> () throws -> Data = { credentialsPath in
-                return {
-                    let infix: String
-                    if let credentialsPrefix = credentialsPath.first, credentialsPrefix != "/" {
-                        infix = "/"
-                    } else {
-                        infix = ""
-                    }
-                    
-                    let completedSemaphore = DispatchSemaphore(value: 0)
-                    var result: Result<HTTPClient.Response, Error>?
-                    let endpoint = "http://\(credentialsHost)\(infix)\(credentialsPath)"
-                    
-                    let headers = [("User-Agent", "SmokeAWSCredentials"),
-                        ("Content-Length", "0"),
-                        ("Host", credentialsHost),
-                        ("Accept", "*/*")]
-                    
-                    credentialsLogger.trace("Retrieving environment credentials from endpoint: \(endpoint)")
-                    
-                    let request = try HTTPClient.Request(url: endpoint, method: .GET, headers: HTTPHeaders(headers))
-                    
-                    let httpClient = HTTPClient(eventLoopGroupProvider: eventLoopProvider)
-                    httpClient.execute(request: request).whenComplete { returnedResult in
-                        result = returnedResult
-                        completedSemaphore.signal()
-                    }
-                    defer {
-                        try? httpClient.syncShutdown()
-                    }
-                    
-                    completedSemaphore.wait()
-                    
-                    guard let theResult = result else {
-                        throw CredentialsHTTPError.noResponse
-                    }
-                    
-                    switch theResult {
-                    case .success(let response):
-                        // if the response status is ok
-                        if case .ok = response.status {
-                            if var body = response.body {
-                                let byteBufferSize = body.readableBytes
-                                return body.readData(length: byteBufferSize) ?? Data()
-                            } else {
-                                return Data()
-                            }
-                        }
-                        
-                        let bodyAsString: String?
-                        if var body = response.body {
-                            let byteBufferSize = body.readableBytes
-                            let data = body.readData(length: byteBufferSize) ?? Data()
-                            
-                            bodyAsString = String(data: data, encoding: .utf8)
-                        } else {
-                            bodyAsString = nil
-                        }
-                        
-                        throw CredentialsHTTPError.errorResponse(response.status.code, bodyAsString)
-                    case .failure(let error):
-                        throw error
-                    }
-                }
-            }
-            
-            return get(fromEnvironment: environment,
-                       reporting: reporting,
-                       dataRetrieverProvider: dataRetrieverProvider)
+        fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
+        logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew)
+    -> StoppableCredentialsProvider? {
+        return get(fromEnvironment: environment,
+                   containerRetrieverType: ContainerExpiringCredentialsRetriever.self,
+                   devRetrieverType: DevExpiringCredentialsRetriever.self,
+                   logger: logger, eventLoopProvider: eventLoopProvider)
     }
     
     /**
-     Internal static function for testing.
+     Internal entry point for testing
      */
-    internal static func get<InvocationReportingType: HTTPClientCoreInvocationReporting>(
+    internal static func get<ContainerRetrieverType: ContainerExpiringCredentialsRetrieverProtocol,
+                             DevRetrieverType: DevExpiringCredentialsRetrieverProtocol>(
             fromEnvironment environment: [String: String],
-            reporting: InvocationReportingType,
-            dataRetrieverProvider: (String) -> () throws -> Data)
+            containerRetrieverType: ContainerRetrieverType.Type, devRetrieverType: DevRetrieverType.Type,
+            logger originalLogger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+            eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew)
         -> StoppableCredentialsProvider? {
-            var credentialsProvider: StoppableCredentialsProvider?
-            if let rotatingCredentials = getRotatingCredentialsProvider(
-                fromEnvironment: environment,
-                reporting: reporting,
-                dataRetrieverProvider: dataRetrieverProvider) {
-                    credentialsProvider = rotatingCredentials
+            var logger = originalLogger
+            logger[metadataKey: "credentials.source"] = "environment"
+            
+            if let rotatingCredentials = getContainerRotatingCredentialsProvider(fromEnvironment: environment,
+                                                                                 retrieverType: containerRetrieverType,
+                                                                                 eventLoopProvider: eventLoopProvider,
+                                                                                 logger: logger) {
+                return rotatingCredentials
             }
             
-            if credentialsProvider == nil,
-                let staticCredentials = getStaticCredentialsProvider(
-                    fromEnvironment: environment,
-                    reporting: reporting,
-                    dataRetrieverProvider: dataRetrieverProvider) {
-                        credentialsProvider = staticCredentials
+            if let staticCredentials = getStaticCredentialsProvider(fromEnvironment: environment, logger: logger) {
+                return staticCredentials
             }
             
             #if DEBUG
-            if credentialsProvider == nil,
-                let rotatingCredentials = getDevRotatingCredentialsProvider(
-                    fromEnvironment: environment,
-                    reporting: reporting) {
-                    credentialsProvider = rotatingCredentials
+            if let rotatingCredentials = getDevRotatingCredentialsProvider(fromEnvironment: environment,
+                                                                           retrieverType: devRetrieverType,
+                                                                           logger: logger) {
+                return rotatingCredentials
             }
             #endif
             
-            return credentialsProvider
+            return nil
     }
     
-    private static func getStaticCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
+    private static func getStaticCredentialsProvider(
         fromEnvironment environment: [String: String],
-        reporting: InvocationReportingType,
-        dataRetrieverProvider: (String) -> () throws -> Data)
+        logger: Logger)
         -> StoppableCredentialsProvider? {
             // get the values of the environment variables
             let awsAccessKeyId = environment["AWS_ACCESS_KEY_ID"]
@@ -222,12 +143,12 @@ public extension AwsContainerRotatingCredentialsProvider {
             guard let secretAccessKey = awsSecretAccessKey, let accessKeyId = awsAccessKeyId else {
                 let logMessage = "'AWS_ACCESS_KEY_ID' and 'AWS_SESSION_TOKEN' environment variables not"
                     + "specified. Static credentials not available."
-                reporting.logger.trace("\(logMessage)")
+                logger.trace("\(logMessage)")
                 
                 return nil
             }
             
-            reporting.logger.trace("Static credentials retrieved from environment.")
+            logger.trace("Static credentials retrieved from environment.")
             
             // return these credentials
             return SmokeAWSCore.StaticCredentials(accessKeyId: accessKeyId,
@@ -236,9 +157,11 @@ public extension AwsContainerRotatingCredentialsProvider {
     }
     
 #if DEBUG
-    private static func getDevRotatingCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
+    private static func getDevRotatingCredentialsProvider<RetrieverType: DevExpiringCredentialsRetrieverProtocol>(
             fromEnvironment environment: [String: String],
-            reporting: InvocationReportingType) -> StoppableCredentialsProvider? {
+            retrieverType: RetrieverType.Type,
+            logger: Logger)
+    -> StoppableCredentialsProvider? {
         // get the values of the environment variables
         let devCredentialsIamRoleArn = environment["DEV_CREDENTIALS_IAM_ROLE_ARN"]
         
@@ -246,55 +169,40 @@ public extension AwsContainerRotatingCredentialsProvider {
             let logMessage = "'DEV_CREDENTIALS_IAM_ROLE_ARN' environment variable not specified."
                 + " Dev rotating credentials not available."
             
-            reporting.logger.trace("\(logMessage)")
+            logger.trace("\(logMessage)")
             
             return nil
         }
         
-        let dataRetriever: () throws -> Data = {
-            let outputPipe = Pipe()
-            
-            let task = Process()
-            #if os(Linux) && (swift(>=5.0) || (swift(>=4.1.50) && !swift(>=4.2)) || (swift(>=3.5) && !swift(>=4.0)))
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            #else
-            task.launchPath = "/usr/bin/env"
-            #endif
-            task.arguments = ["/usr/local/bin/get-credentials.sh",
-                              "-r",
-                              iamRoleArn,
-                              "-d",
-                              "900"]
-            task.standardOutput = outputPipe
-            #if os(Linux) && swift(>=5.0)
-            try task.run()
-            #else
-            task.launch()
-            #endif
-            task.waitUntilExit()
-
-            return outputPipe.fileHandleForReading.availableData
-        }
+        let credentialsRetriever = RetrieverType(iamRoleArn: iamRoleArn)
         
-        let rotatingCredentialsProvider: StoppableCredentialsProvider
         do {
-            rotatingCredentialsProvider = try createRotatingCredentialsProvider(
-                reporting: reporting, dataRetriever: dataRetriever)
+            let awsContainerRotatingCredentialsProvider =
+                try AwsRotatingCredentialsProviderV2(
+                        expiringCredentialsRetriever: credentialsRetriever,
+                        roleSessionName: nil,
+                        logger: logger)
+            
+            awsContainerRotatingCredentialsProvider.start()
+            
+            logger.trace("Rotating credentials retrieved from environment.")
+            
+            // return the credentials
+            return awsContainerRotatingCredentialsProvider
         } catch {
-            reporting.logger.error("Retrieving dev rotating credentials rotation failed: '\(error)'")
+            logger.error("Retrieving rotating credentials rotation failed: '\(error)'")
             
             return nil
         }
-        
-        return rotatingCredentialsProvider
     }
 #endif
     
-    private static func getRotatingCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
+    private static func getContainerRotatingCredentialsProvider<RetrieverType: ContainerExpiringCredentialsRetrieverProtocol>(
         fromEnvironment environment: [String: String],
-        reporting: InvocationReportingType,
-        dataRetrieverProvider: (String) -> () throws -> Data)
-        -> StoppableCredentialsProvider? {
+        retrieverType: RetrieverType.Type,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider,
+        logger: Logger)
+    -> StoppableCredentialsProvider? {
         // get the values of the environment variables
         let awsContainerCredentialsRelativeUri = environment["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
         
@@ -302,67 +210,337 @@ public extension AwsContainerRotatingCredentialsProvider {
             let logMessage = "'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' environment variable not specified."
                 + " Rotating credentials not available."
             
-            reporting.logger.trace("\(logMessage)")
+            logger.trace("\(logMessage)")
             
             return nil
         }
         
-        let dataRetriever = dataRetrieverProvider(credentialsPath)
-        let rotatingCredentialsProvider: StoppableCredentialsProvider
+        let credentialsRetriever = RetrieverType(eventLoopProvider: eventLoopProvider, credentialsPath: credentialsPath,
+                                                 logger: logger)
+            
         do {
-            rotatingCredentialsProvider = try createRotatingCredentialsProvider(
-                reporting: reporting,
-                dataRetriever: dataRetriever)
+            let awsContainerRotatingCredentialsProvider =
+                try AwsRotatingCredentialsProviderV2(
+                        expiringCredentialsRetriever: credentialsRetriever,
+                        roleSessionName: nil,
+                        logger: logger)
+            
+            awsContainerRotatingCredentialsProvider.start()
+            
+            logger.trace("Rotating credentials retrieved from environment.")
+            
+            // return the credentials
+            return awsContainerRotatingCredentialsProvider
         } catch {
-            reporting.logger.error("Retrieving rotating credentials rotation failed: '\(error)'")
+            logger.error("Retrieving rotating credentials rotation failed: '\(error)'")
+            
+            return nil
+        }
+    }
+}
+
+public extension AwsContainerRotatingCredentialsProviderV2 {
+    // the endpoint for obtaining credentials from the ECS container
+    // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+    private static let credentialsHost = "169.254.170.2"
+    private static let credentialsPort = 80
+    
+    /**
+     The Environment variable that can be passed in conjunction with
+     the DEBUG compiler flag to gain credentials based on the
+     IAM Role ARN specified.
+ 
+     If this Environment variable and the DEBUG compiler flag are specified,
+     this class will first attempt to obtain credentials from the container
+     environment and then static credentials under the AWS_SECRET_ACCESS_KEY
+     and AWS_ACCESS_KEY_ID keys. If neither are present, this class will call
+     the shell script-
+       /usr/local/bin/get-credentials.sh -r <role> -d <role lifetype>
+     
+     This script should write to its standard output a JSON structure capable of
+     being decoded into the ExpiringCredentials structure.
+     */
+    static let devIamRoleArnEnvironmentVariable = "DEV_CREDENTIALS_IAM_ROLE_ARN"
+    
+    /**
+     Static function that retrieves credentials provider from the specified environment -
+     either rotating credentials retrieved from an endpoint specified under the
+     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI key or if that key isn't present,
+     static credentials under the AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID keys.
+     */
+    static func get(
+        fromEnvironment environment: [String: String] = ProcessInfo.processInfo.environment,
+        logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) async
+    -> StoppableCredentialsProvider? {
+        return await get(fromEnvironment: environment,
+                         containerRetrieverType: ContainerExpiringCredentialsRetriever.self,
+                         devRetrieverType: DevExpiringCredentialsRetriever.self,
+                         logger: logger, eventLoopProvider: eventLoopProvider)
+    }
+    
+    /**
+     Internal entry point for testing
+     */
+    internal static func get<ContainerRetrieverType: ContainerExpiringCredentialsRetrieverProtocol,
+                             DevRetrieverType: DevExpiringCredentialsRetrieverProtocol>(
+            fromEnvironment environment: [String: String],
+            containerRetrieverType: ContainerRetrieverType.Type, devRetrieverType: DevRetrieverType.Type,
+            logger originalLogger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+            eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) async
+        -> StoppableCredentialsProvider? {
+            var logger = originalLogger
+            logger[metadataKey: "credentials.source"] = "environment"
+            
+            if let rotatingCredentials = await getContainerRotatingCredentialsProvider(fromEnvironment: environment,
+                                                                                       retrieverType: containerRetrieverType,
+                                                                                       eventLoopProvider: eventLoopProvider,
+                                                                                       logger: logger) {
+                return rotatingCredentials
+            }
+            
+            if let staticCredentials = getStaticCredentialsProvider(fromEnvironment: environment, logger: logger) {
+                return staticCredentials
+            }
+            
+            #if DEBUG
+            if let rotatingCredentials = await getDevRotatingCredentialsProvider(fromEnvironment: environment,
+                                                                                 retrieverType: devRetrieverType,
+                                                                                 logger: logger) {
+                return rotatingCredentials
+            }
+            #endif
+            
+            return nil
+    }
+    
+    private static func getStaticCredentialsProvider(
+        fromEnvironment environment: [String: String],
+        logger: Logger)
+        -> StoppableCredentialsProvider? {
+            // get the values of the environment variables
+            let awsAccessKeyId = environment["AWS_ACCESS_KEY_ID"]
+            let awsSecretAccessKey = environment["AWS_SECRET_ACCESS_KEY"]
+            let sessionToken = environment["AWS_SESSION_TOKEN"]
+            
+            guard let secretAccessKey = awsSecretAccessKey, let accessKeyId = awsAccessKeyId else {
+                let logMessage = "'AWS_ACCESS_KEY_ID' and 'AWS_SESSION_TOKEN' environment variables not"
+                    + "specified. Static credentials not available."
+                logger.trace("\(logMessage)")
+                
+                return nil
+            }
+            
+            logger.trace("Static credentials retrieved from environment.")
+            
+            // return these credentials
+            return SmokeAWSCore.StaticCredentials(accessKeyId: accessKeyId,
+                                                  secretAccessKey: secretAccessKey,
+                                                  sessionToken: sessionToken)
+    }
+    
+#if DEBUG
+    private static func getDevRotatingCredentialsProvider<RetrieverType: DevExpiringCredentialsRetrieverProtocol>(
+            fromEnvironment environment: [String: String],
+            retrieverType: RetrieverType.Type,
+            logger: Logger) async
+    -> StoppableCredentialsProvider? {
+        // get the values of the environment variables
+        let devCredentialsIamRoleArn = environment["DEV_CREDENTIALS_IAM_ROLE_ARN"]
+        
+        guard let iamRoleArn = devCredentialsIamRoleArn else {
+            let logMessage = "'DEV_CREDENTIALS_IAM_ROLE_ARN' environment variable not specified."
+                + " Dev rotating credentials not available."
+            
+            logger.trace("\(logMessage)")
             
             return nil
         }
         
-        return rotatingCredentialsProvider
-    }
-    
-    private static func createRotatingCredentialsProvider<InvocationReportingType: HTTPClientCoreInvocationReporting>(
-        reporting: InvocationReportingType,
-        dataRetriever: @escaping () throws -> Data) throws
-    -> StoppableCredentialsProvider {
-        let credentialsRetriever = FromDataExpiringCredentialsRetriever(
-            dataRetriever: dataRetriever)
+        let credentialsRetriever = RetrieverType(iamRoleArn: iamRoleArn)
+        
+        do {
+            let awsContainerRotatingCredentialsProvider =
+                try await AwsRotatingCredentialsProviderV2(
+                        expiringCredentialsRetriever: credentialsRetriever,
+                        roleSessionName: nil,
+                        logger: logger)
             
-        let awsContainerRotatingCredentialsProvider =
-            try AwsContainerRotatingCredentialsProvider(
-                expiringCredentialsRetriever: credentialsRetriever)
+            awsContainerRotatingCredentialsProvider.start()
+            
+            logger.trace("Rotating credentials retrieved from environment.")
+            
+            // return the credentials
+            return awsContainerRotatingCredentialsProvider
+        } catch {
+            logger.error("Retrieving rotating credentials rotation failed: '\(error)'")
+            
+            return nil
+        }
+    }
+#endif
+    
+    private static func getContainerRotatingCredentialsProvider<RetrieverType: ContainerExpiringCredentialsRetrieverProtocol>(
+        fromEnvironment environment: [String: String],
+        retrieverType: RetrieverType.Type,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider,
+        logger: Logger) async
+    -> StoppableCredentialsProvider? {
+        // get the values of the environment variables
+        let awsContainerCredentialsRelativeUri = environment["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
         
-        awsContainerRotatingCredentialsProvider.start(
-            roleSessionName: nil,
-            reporting: reporting)
+        guard let credentialsPath = awsContainerCredentialsRelativeUri else {
+            let logMessage = "'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' environment variable not specified."
+                + " Rotating credentials not available."
+            
+            logger.trace("\(logMessage)")
+            
+            return nil
+        }
         
-        reporting.logger.trace("Rotating credentials retrieved from environment.")
-        
-        // return the credentials
-        return awsContainerRotatingCredentialsProvider
+        let credentialsRetriever = RetrieverType(eventLoopProvider: eventLoopProvider, credentialsPath: credentialsPath,
+                                                 logger: logger)
+            
+        do {
+            let awsContainerRotatingCredentialsProvider =
+                try await AwsRotatingCredentialsProviderV2(
+                        expiringCredentialsRetriever: credentialsRetriever,
+                        roleSessionName: nil,
+                        logger: logger)
+            
+            awsContainerRotatingCredentialsProvider.start()
+            
+            logger.trace("Rotating credentials retrieved from environment.")
+            
+            // return the credentials
+            return awsContainerRotatingCredentialsProvider
+        } catch {
+            logger.error("Retrieving rotating credentials rotation failed: '\(error)'")
+            
+            return nil
+        }
+    }
+}
+
+internal struct DevExpiringCredentialsRetriever: DevExpiringCredentialsRetrieverProtocol {
+    let iamRoleArn: String
+    
+    func shutdown() async throws {
+        // nothing to do
+    }
+
+    func close() throws {
+        // nothing to do
     }
     
-    internal struct FromDataExpiringCredentialsRetriever: ExpiringCredentialsRetriever {
-        let dataRetriever: () throws -> Data
+    func get() throws -> ExpiringCredentials {
+        let outputPipe = Pipe()
         
-        func close() {
-            // nothing to do
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = ["/usr/local/bin/get-credentials.sh",
+                          "-r",
+                          self.iamRoleArn,
+                          "-d",
+                          "900"]
+        task.standardOutput = outputPipe
+        try task.run()
+        task.waitUntilExit()
+
+        let bodyData = outputPipe.fileHandleForReading.availableData
+        
+        return try ExpiringCredentials.getCurrentCredentials(data: bodyData)
+    }
+
+    func getCredentials() async throws -> ExpiringCredentials {
+        return try get()
+    }
+}
+
+internal struct ContainerExpiringCredentialsRetriever: ContainerExpiringCredentialsRetrieverProtocol {
+    let httpClient: HTTPClient
+    let credentialsPath: String
+    let logger: Logger
+    
+    init(eventLoopProvider: HTTPClient.EventLoopGroupProvider, credentialsPath: String, logger: Logger) {
+        self.httpClient = HTTPClient(eventLoopGroupProvider: eventLoopProvider)
+        self.credentialsPath = credentialsPath
+        self.logger = logger
+    }
+    
+    // the endpoint for obtaining credentials from the ECS container
+    // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+    private static let credentialsHost = "169.254.170.2"
+    private static let credentialsPort = 80
+    
+    func shutdown() async throws {
+        try await self.httpClient.shutdown()
+    }
+    
+    func close() throws {
+        try self.httpClient.syncShutdown()
+    }
+    
+    func get() throws -> ExpiringCredentials {
+        let request = try getRequest()
+        
+        let response = try self.httpClient.execute(request: request).wait()
+        
+        return try handle(response: response)
+    }
+    
+    func getCredentials() async throws -> ExpiringCredentials {
+        let request = try getRequest()
+        
+        let response = try await self.httpClient.execute(request: request).get()
+        
+        return try handle(response: response)
+    }
+    
+    private func getRequest() throws -> HTTPClient.Request {
+        let infix: String
+        if let credentialsPrefix = self.credentialsPath.first, credentialsPrefix != "/" {
+            infix = "/"
+        } else {
+            infix = ""
         }
         
-#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
-        func shutdown() async throws {
-            // nothing to do
-        }
-#endif
+        let endpoint = "http://\(Self.credentialsHost)\(infix)\(self.credentialsPath)"
         
-        func wait() {
-            // nothing to do
-        }
+        let headers = [("User-Agent", "SmokeAWSCredentials"),
+            ("Content-Length", "0"),
+            ("Host", Self.credentialsHost),
+            ("Accept", "*/*")]
         
-        func get() throws -> ExpiringCredentials {
-            return try ExpiringCredentials.getCurrentCredentials(
-                    dataRetriever: dataRetriever)
+        self.logger.trace("Retrieving environment credentials from endpoint: \(endpoint)")
+        
+        return try HTTPClient.Request(url: endpoint, method: .GET, headers: HTTPHeaders(headers))
+    }
+    
+    private func handle(response: HTTPClient.Response) throws -> ExpiringCredentials {
+        // if the response status is ok
+        guard case .ok = response.status else {
+            let bodyAsString: String?
+            if var body = response.body {
+                let byteBufferSize = body.readableBytes
+                let data = body.readData(length: byteBufferSize) ?? Data()
+                
+                bodyAsString = String(data: data, encoding: .utf8)
+            } else {
+                bodyAsString = nil
+            }
+            
+            throw CredentialsHTTPError.errorResponse(response.status.code, bodyAsString)
         }
+            
+        let bodyData: Data
+        if var body = response.body {
+            let byteBufferSize = body.readableBytes
+            bodyData = body.readData(length: byteBufferSize) ?? Data()
+        } else {
+            bodyData = Data()
+        }
+            
+        return try ExpiringCredentials.getCurrentCredentials(data: bodyData)
     }
 }

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
@@ -20,12 +20,6 @@ import SmokeHTTPClient
 import SmokeAWSCore
 import Logging
 
-#if os(Linux)
-	import Glibc
-#else
-	import Darwin
-#endif
-
 internal extension NSLocking {
     func withLock<R>(_ body: () throws -> R) rethrows -> R {
         self.lock()
@@ -188,7 +182,7 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
     }
     
     public func shutdown() async throws {
-        let isShutdown = self.statusLock.withLock {
+        let isShutdown = self.statusLock.withLock { () -> Bool in
             // if there is currently a worker to shutdown
             switch status {
             case .initialized:

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
@@ -1,0 +1,295 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AwsRotatingCredentials.swift
+//  SmokeAWSCredentials
+//
+
+import Foundation
+import SmokeHTTPClient
+import SmokeAWSCore
+import Logging
+
+private let secondsToNanoSeconds: UInt64 = 1_000_000_000
+
+/**
+ A protocol that retrieves `ExpiringCredentials` and that is closable.
+ */
+public protocol ExpiringCredentialsRetrieverV2: ExpiringCredentialsRetriever {
+    
+    /**
+     Retrieves a new instance of `ExpiringCredentials`.
+     */
+    func getCredentials() async throws -> ExpiringCredentials
+}
+
+/**
+ Class that manages the rotating credentials.
+ */
+public class AwsRotatingCredentialsProviderV2: StoppableCredentialsProvider {
+    public var credentials: Credentials {
+        // the provider returns a copy of the current
+        // credentials which is used within a request.
+        // The provider is then free to rotate credentials
+        // without the risk of rotation causing inconsistent
+        // credentials to be used across a request.
+        return self.statusLock.withLock {
+            return expiringCredentials
+        }
+    }
+    
+    private var expiringCredentials: ExpiringCredentials
+    
+    let expirationBufferSeconds = 300.0 // 5 minutes
+    let validCredentialsRetrySeconds = 60.0 // 1 minute
+    let invalidCredentialsRetrySeconds = 3600.0 // 1 hour
+    
+    let roleSessionName: String?
+    let logger: Logger
+    
+    public enum Status {
+        case initialized
+        case running
+        case shuttingDown
+        case stopped
+    }
+    
+    public var status: Status
+    let completedSemaphore = DispatchSemaphore(value: 0)
+    var statusLock: NSLock = NSLock()
+    let expiringCredentialsRetriever: ExpiringCredentialsRetrieverV2
+    
+    /**
+     Initializer that accepts the initial ExpiringCredentials instance for this provider.
+     
+     - Parameters:
+        - expiringCredentialsRetriever: retriever of expiring credentials.
+     */
+    @available(swift, deprecated: 3.0, message: "Migrate to async constructor")
+    public init(expiringCredentialsRetriever: ExpiringCredentialsRetrieverV2,
+                roleSessionName: String?,
+                logger: Logger) throws {
+        self.expiringCredentials = try expiringCredentialsRetriever.get()
+        self.expiringCredentialsRetriever = expiringCredentialsRetriever
+        self.roleSessionName = roleSessionName
+        self.logger = logger
+        self.status = .initialized
+    }
+    
+    public init(expiringCredentialsRetriever: ExpiringCredentialsRetrieverV2,
+                roleSessionName: String?,
+                logger: Logger) async throws {
+        self.expiringCredentials = try await expiringCredentialsRetriever.getCredentials()
+        self.expiringCredentialsRetriever = expiringCredentialsRetriever
+        self.roleSessionName = roleSessionName
+        self.logger = logger
+        self.status = .initialized
+    }
+    
+    deinit {
+        try? stop()
+        wait()
+    }
+    
+    /**
+     Schedules credentials rotation to begin.
+     */
+    public func start() {
+        self.statusLock.withLock {
+            guard case .initialized = status else {
+                // if this instance isn't in the initialized state, do nothing
+                return
+            }
+            
+            // only actually need to start updating credentials if the
+            // initial ones expire
+            if self.expiringCredentials.expiration != nil {
+                Task(priority: .medium) {
+                    await run()
+                }
+                
+                self.status = .running
+            }
+            
+            return
+        }
+    }
+    
+    /**
+     Gracefully shuts down credentials rotation, letting any ongoing work complete..
+     */
+    public func stop() throws {
+        try self.statusLock.withLock {
+            // if there is currently a worker to shutdown
+            switch status {
+            case .initialized:
+                // no worker ever started, can just go straight to stopped
+                status = .stopped
+                try expiringCredentialsRetriever.syncShutdown()
+                completedSemaphore.signal()
+            case .running:
+                status = .shuttingDown
+                try expiringCredentialsRetriever.syncShutdown()
+            default:
+                // nothing to do
+                break
+            }
+        }
+    }
+    
+    public func shutdown() async throws {
+        let isShutdown = self.statusLock.withLock {
+            // if there is currently a worker to shutdown
+            switch status {
+            case .initialized:
+                // no worker ever started, can just go straight to stopped
+                status = .stopped
+                completedSemaphore.signal()
+                return true
+            case .running:
+                status = .shuttingDown
+                return true
+            default:
+                // nothing to do
+                break
+            }
+            
+            return false
+        }
+        
+        if isShutdown {
+            try await expiringCredentialsRetriever.shutdown()
+        }
+    }
+    
+    private func verifyWorkerNotStopped() -> Bool {
+        return self.statusLock.withLock {
+            guard case .stopped = status else {
+                return false
+            }
+            
+            return true
+        }
+    }
+    
+    /**
+     Waits for the work to exit.
+     If stop() is not called, this will block forever.
+     */
+    public func wait() {
+        guard self.verifyWorkerNotStopped() else {
+            return
+        }
+        
+        completedSemaphore.wait()
+    }
+    
+    private func verifyWorkerNotCancelled() -> Bool {
+        return self.statusLock.withLock {
+            guard case .running = status else {
+                status = .stopped
+                completedSemaphore.signal()
+                return false
+            }
+            
+            return true
+        }
+    }
+    
+    func run() async {
+        var expiration: Date? = self.expiringCredentials.expiration
+                
+        while let currentExpiration = expiration {
+            guard self.verifyWorkerNotCancelled() else {
+                return
+            }
+            
+            // create a deadline 5 minutes before the expiration
+            let timeInterval = (currentExpiration - expirationBufferSeconds).timeIntervalSinceNow
+            let timeInternalInMinutes = timeInterval / 60
+            
+            let minutes: Int = Int(timeInternalInMinutes) % 60
+            let hours: Int = Int(timeInternalInMinutes) / 60
+                        
+            let logEntryPrefix: String
+            if let roleSessionName = self.roleSessionName {
+                logEntryPrefix = "Credentials for session '\(roleSessionName)'"
+            } else {
+                logEntryPrefix = "Credentials"
+            }
+            
+            self.logger.trace(
+                "\(logEntryPrefix) updated; rotation scheduled in \(hours) hours, \(minutes) minutes.")
+            do {
+                try await Task.sleep(nanoseconds: UInt64(timeInterval) * secondsToNanoSeconds)
+            } catch {
+                self.logger.error(
+                    "\(logEntryPrefix) rotation stopped due to error \(error).")
+            }
+            
+            expiration = await updateCredentials(roleSessionName: roleSessionName, logger: logger)
+        }
+    }
+    
+    private func updateCredentials(roleSessionName: String?,
+                                   logger: Logger) async
+    -> Date? {
+        let logEntryPrefix: String
+        if let roleSessionName = roleSessionName {
+            logEntryPrefix = "Credentials for session '\(roleSessionName)'"
+        } else {
+            logEntryPrefix = "Credentials"
+        }
+        
+        self.logger.trace("\(logEntryPrefix) about to expire; rotating.")
+        
+        let expiration: Date?
+        do {
+            let expiringCredentials = try await self.expiringCredentialsRetriever.getCredentials()
+            
+            self.statusLock.withLock {
+                self.expiringCredentials = expiringCredentials
+            }
+            
+            expiration = expiringCredentials.expiration
+        } catch {
+            let timeIntervalSinceNow =
+                self.expiringCredentials.expiration?.timeIntervalSinceNow ?? 0
+            
+            let retryDuration: Double
+            let logPrefix = "\(logEntryPrefix) rotation failed."
+            
+            // if the expiry of the current credentials is still in the future
+            if timeIntervalSinceNow > 0 {
+                // try again relatively soon (still within the 5 minute credentials
+                // expirary buffer) to get new credentials
+                retryDuration = self.validCredentialsRetrySeconds
+                
+                self.logger.warning(
+                    "\(logPrefix) Credentials still valid. Attempting credentials refresh in 1 minute.")
+            } else {
+                // at this point, we have tried multiple times to get new credentials
+                // something is quite wrong; try again in the future but at
+                // a reduced frequency
+                retryDuration = self.invalidCredentialsRetrySeconds
+                
+                self.logger.error(
+                    "\(logPrefix) Credentials no longer valid. Attempting credentials refresh in 1 hour.")
+            }
+            
+            expiration = Date(timeIntervalSinceNow: retryDuration)
+        }
+        
+        return expiration
+    }
+}

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
@@ -148,7 +148,7 @@ public class AwsRotatingCredentialsProviderV2: StoppableCredentialsProvider {
     }
     
     public func shutdown() async throws {
-        let isShutdown = self.statusLock.withLock {
+        let isShutdown = self.statusLock.withLock { () -> Bool in
             // if there is currently a worker to shutdown
             switch status {
             case .initialized:

--- a/Sources/SmokeAWSCredentials/ExpiringCredentials.swift
+++ b/Sources/SmokeAWSCredentials/ExpiringCredentials.swift
@@ -84,6 +84,10 @@ public struct ExpiringCredentials: Codable, SmokeAWSCore.Credentials {
     static func getCurrentCredentials(dataRetriever: () throws -> Data) throws -> ExpiringCredentials {
         let data = try dataRetriever()
         
+        return try getCurrentCredentials(data: data)
+    }
+    
+    static func getCurrentCredentials(data: Data) throws -> ExpiringCredentials {
         let expiringCredentials = try jsonDecoder.decode(ExpiringCredentials.self, from: data)
         
         // ensure we are not getting junk credentials data

--- a/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/SecurityTokenClientProtocol+getAssumedCredentials.swift
@@ -28,7 +28,7 @@ enum AssumingRoleError: Error {
     case noCredentialsReturned(arn: String)
 }
 
-internal struct AWSSTSExpiringCredentialsRetriever<InvocationReportingType: HTTPClientCoreInvocationReporting>: ExpiringCredentialsRetriever {
+internal struct AWSSTSExpiringCredentialsRetriever<InvocationReportingType: HTTPClientCoreInvocationReporting>: ExpiringCredentialsRetrieverV2 {
     let client: AWSSecurityTokenClient<InvocationReportingType>
     let roleArn: String
     let roleSessionName: String
@@ -55,14 +55,20 @@ internal struct AWSSTSExpiringCredentialsRetriever<InvocationReportingType: HTTP
         try self.client.syncShutdown()
     }
 
-    #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     func shutdown() async throws {
         try await self.client.shutdown()
     }
-    #endif
     
+    @available(*, deprecated, renamed: "getCredentials")
     func get() throws -> ExpiringCredentials {
         return try client.getAssumedExpiringCredentials(
+                    roleArn: roleArn,
+                    roleSessionName: roleSessionName,
+                    durationSeconds: durationSeconds)
+    }
+    
+    func getCredentials() async throws -> ExpiringCredentials {
+        return try await client.getAssumedExpiringCredentialsV2(
                     roleArn: roleArn,
                     roleSessionName: roleSessionName,
                     durationSeconds: durationSeconds)
@@ -81,6 +87,7 @@ extension SecurityTokenClientProtocol {
             range from 900 seconds (15 minutes) to 3600 seconds (1 hour). By default, the value
             is set to 3600 seconds.
      */
+    @available(*, deprecated, renamed: "getAssumedExpiringCredentialsV2")
     internal func getAssumedExpiringCredentials(roleArn: String,
                                                 roleSessionName: String,
                                                 durationSeconds: Int?) throws -> ExpiringCredentials {
@@ -106,9 +113,35 @@ extension SecurityTokenClientProtocol {
                                    sessionToken: stsCredentials.sessionToken)
     }
     
+    internal func getAssumedExpiringCredentialsV2(roleArn: String,
+                                                  roleSessionName: String,
+                                                  durationSeconds: Int?) async throws -> ExpiringCredentials {
+        let input = SecurityTokenModel.AssumeRoleRequest(durationSeconds: durationSeconds,
+                                                         roleArn: roleArn,
+                                                         roleSessionName: roleSessionName)
+        
+        let output: SecurityTokenModel.AssumeRoleResponseForAssumeRole
+        do {
+            // call to assume the role
+            output = try await assumeRole(input: input)
+        } catch {
+            throw AssumingRoleError.unableToAssumeRole(arn: roleArn, error: error)
+        }
+        
+        guard let stsCredentials = output.assumeRoleResult.credentials else {
+            throw AssumingRoleError.noCredentialsReturned(arn: roleArn)
+        }
+    
+        return ExpiringCredentials(accessKeyId: stsCredentials.accessKeyId,
+                                   expiration: stsCredentials.expiration.dateFromISO8601String ?? nil,
+                                   secretAccessKey: stsCredentials.secretAccessKey,
+                                   sessionToken: stsCredentials.sessionToken)
+    }
+    
     /**
      Function that retrieves StaticCredentials from the provided token service.
      */
+    @available(*, deprecated, renamed: "getAssumedStaticCredentialsV2")
     internal static func getAssumedStaticCredentials<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         roleArn: String,
         roleSessionName: String,
@@ -141,8 +174,43 @@ extension SecurityTokenClientProtocol {
     }
     
     /**
+     Function that retrieves StaticCredentials from the provided token service.
+     */
+    internal static func getAssumedStaticCredentialsV2<InvocationReportingType: HTTPClientCoreInvocationReporting>(
+        roleArn: String,
+        roleSessionName: String,
+        credentialsProvider: CredentialsProvider,
+        reporting: InvocationReportingType,
+        retryConfiguration: HTTPClientRetryConfiguration) async -> StaticCredentials? {
+        let securityTokenClient = AWSSecurityTokenClient(
+            credentialsProvider: credentialsProvider,
+            reporting: reporting,
+            retryConfiguration: retryConfiguration)
+        defer {
+            try? securityTokenClient.syncShutdown()
+        }
+        
+        let delegatedCredentials: ExpiringCredentials
+        do {
+            delegatedCredentials = try await securityTokenClient.getAssumedExpiringCredentialsV2(
+                roleArn: roleArn,
+                roleSessionName: roleSessionName,
+                durationSeconds: nil)
+        } catch {
+            reporting.logger.warning("Unable to assumed delegated rotating credentials: \(error).")
+    
+            return nil
+        }
+        
+        return StaticCredentials(accessKeyId: delegatedCredentials.accessKeyId,
+                                 secretAccessKey: delegatedCredentials.secretAccessKey,
+                                 sessionToken: delegatedCredentials.sessionToken)
+    }
+    
+    /**
      Function that retrieves AssumedRotatingCredentials from the provided token service.
      */
+    @available(*, deprecated, renamed: "getAssumedRotatingCredentialsV2")
     internal static func getAssumedRotatingCredentials<InvocationReportingType: HTTPClientCoreInvocationReporting>(
         roleArn: String,
         roleSessionName: String,
@@ -160,18 +228,51 @@ extension SecurityTokenClientProtocol {
             eventLoopProvider: eventLoopProvider,
             reporting: reporting)
         
-        let delegatedRotatingCredentials: AwsRotatingCredentialsProvider
+        let delegatedRotatingCredentials: AwsRotatingCredentialsProviderV2
         do {
-            delegatedRotatingCredentials = try AwsRotatingCredentialsProvider(
-                expiringCredentialsRetriever: credentialsRetriever)
+            delegatedRotatingCredentials = try AwsRotatingCredentialsProviderV2(
+                expiringCredentialsRetriever: credentialsRetriever,
+                roleSessionName: roleSessionName, logger: reporting.logger)
         } catch {
             reporting.logger.warning("Unable to assumed delegated rotating credentials: \(error).")
     
             return nil
         }
     
-        delegatedRotatingCredentials.start(roleSessionName: roleSessionName,
-                                           reporting: reporting)
+        delegatedRotatingCredentials.start()
+    
+        return delegatedRotatingCredentials
+    }
+    
+    internal static func getAssumedRotatingCredentialsV2<InvocationReportingType: HTTPClientCoreInvocationReporting>(
+        roleArn: String,
+        roleSessionName: String,
+        credentialsProvider: CredentialsProvider,
+        durationSeconds: Int?,
+        reporting: InvocationReportingType,
+        retryConfiguration: HTTPClientRetryConfiguration,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider) async -> StoppableCredentialsProvider? {
+        let credentialsRetriever = AWSSTSExpiringCredentialsRetriever(
+            credentialsProvider: credentialsProvider,
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            durationSeconds: durationSeconds,
+            retryConfiguration: retryConfiguration,
+            eventLoopProvider: eventLoopProvider,
+            reporting: reporting)
+        
+        let delegatedRotatingCredentials: AwsRotatingCredentialsProviderV2
+        do {
+            delegatedRotatingCredentials = try await AwsRotatingCredentialsProviderV2(
+                expiringCredentialsRetriever: credentialsRetriever,
+                roleSessionName: roleSessionName, logger: reporting.logger)
+        } catch {
+            reporting.logger.warning("Unable to assumed delegated rotating credentials: \(error).")
+    
+            return nil
+        }
+    
+        delegatedRotatingCredentials.start()
     
         return delegatedRotatingCredentials
     }

--- a/Sources/SmokeAWSCredentials/StoppableCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/StoppableCredentialsProvider.swift
@@ -33,9 +33,7 @@ public protocol StoppableCredentialsProvider: CredentialsProvider {
     @available(*, deprecated, renamed: "syncShutdown")
     func stop() throws
     
-#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     func shutdown() async throws
-#endif
 }
 
 public extension StoppableCredentialsProvider {
@@ -44,11 +42,9 @@ public extension StoppableCredentialsProvider {
         try stop()
     }
     
-#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     func shutdown() async throws {
         fatalError("`shutdown() async throws` needs to be implemented on `StoppableCredentialsProvider` conforming type to allow for async shutdown.")
     }
-#endif
 }
 
 /**
@@ -60,9 +56,7 @@ extension SmokeAWSCore.StaticCredentials: StoppableCredentialsProvider {
         // nothing to do
     }
     
-#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     public func shutdown() async throws {
         // nothing to do
     }
-#endif
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import SmokeAWSCredentialsTests
-
-XCTMain([
-    testCase(SmokeAWSCredentialsTests.allTests),
-])

--- a/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderTests.swift
+++ b/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderTests.swift
@@ -64,6 +64,7 @@ class CountingScheduler: AsyncAfterScheduler {
     }
 }
 
+@available(swift, deprecated: 3.0, message: "Testing AwsRotatingCredentialsProvider")
 class AwsRotatingCredentialsProviderTests: XCTestCase {
     func testAlwaysSucceedCredentialsRotation() throws {
         let scheduler = CountingScheduler()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Migrate to using Swift concurrency tasks to manage credential refreshes
2. use NSLock rather than a raw mutex. Ensure there is sufficient locking around retrieving and updating credentials
3. Remove conditional compilation around swift-concurrency code and remove Swift 5.5 support (as per our support document)
4. Add v2 versions of the public APIs that are async, deprecating the existing versions. The only difference between the now deprecated versions and v2 is that the initial credential retrieval will now be done async - in both cases the subsequent background refreshes will use the Swift-concurrency tasks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
