### PR TITLE
Use structured concurrency to background refresh credentials

### DIFF
--- a/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
+++ b/Sources/SmokeAWSCredentials/AwsContainerRotatingCredentialsProvider+get.swift
@@ -180,7 +180,7 @@ public extension AwsContainerRotatingCredentialsProvider {
 
         guard let secretAccessKey = awsSecretAccessKey, let accessKeyId = awsAccessKeyId else {
             let logMessage = "'AWS_ACCESS_KEY_ID' and 'AWS_SESSION_TOKEN' environment variables not"
-                + "specified. Static credentials not available."
+                + " specified. Static credentials not available."
             logger.trace("\(logMessage)")
 
             return nil
@@ -432,6 +432,8 @@ public extension AwsContainerRotatingCredentialsProvider {
 
                 return nil
             }
+            
+            rotatingCredentialsProvider.start()
 
             return rotatingCredentialsProvider
         }
@@ -448,6 +450,8 @@ public extension AwsContainerRotatingCredentialsProvider {
 
                 return nil
             }
+            
+            rotatingCredentialsProvider.start()
 
             return rotatingCredentialsProvider
         }

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
@@ -74,6 +74,13 @@ public extension ExpiringCredentialsRetriever {
     #endif
 }
 
+public protocol ExpiringCredentialsAsyncRetriever: ExpiringCredentialsRetriever {
+    /**
+     Retrieves a new instance of `ExpiringCredentials`.
+     */
+    func getCredentials() async throws -> ExpiringCredentials
+}
+
 /**
  Class that manages the rotating credentials.
  */

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProvider.swift
@@ -258,13 +258,16 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
                                                                                                         roleSessionName: String?,
                                                                                                         reporting: InvocationReportingType) {
         // create a deadline 5 minutes before the expiration
-        let timeInterval = (expiration - self.expirationBufferSeconds).timeIntervalSinceNow
-        let timeInternalInMinutes = timeInterval / 60
+        let waitDurationInSeconds = (expiration - self.expirationBufferSeconds).timeIntervalSinceNow
+        let waitDurationInMinutes = waitDurationInSeconds / 60
 
-        let minutes = Int(timeInternalInMinutes) % 60
-        let hours = Int(timeInternalInMinutes) / 60
+        let wholeNumberOfHours = Int(waitDurationInMinutes) / 60
+        // the total number of minutes minus the number of minutes
+        // that can be expressed in a whole number of hours.
+        // Can also be expressed as: let overflowMinutes = waitDurationInMinutes - (wholeNumberOfHours * 60)
+        let overflowMinutes = Int(waitDurationInMinutes) % 60
 
-        let deadline = DispatchTime.now() + .seconds(Int(timeInterval))
+        let deadline = DispatchTime.now() + .seconds(Int(waitDurationInSeconds))
 
         let logEntryPrefix: String
         if let roleSessionName = roleSessionName {
@@ -325,7 +328,7 @@ public class AwsRotatingCredentialsProvider: StoppableCredentialsProvider {
         }
 
         reporting.logger.trace(
-            "\(logEntryPrefix) updated; rotation scheduled in \(hours) hours, \(minutes) minutes.")
+            "\(logEntryPrefix) updated; rotation scheduled in \(wholeNumberOfHours) hours, \(overflowMinutes) minutes.")
         self.scheduler.asyncAfter(deadline: deadline, qos: .unspecified,
                                   flags: [], execute: newWorker)
 

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
@@ -1,0 +1,282 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AwsRotatingCredentials.swift
+//  SmokeAWSCredentials
+//
+
+import Foundation
+import Logging
+import SmokeAWSCore
+import SmokeHTTPClient
+
+private let secondsToNanoSeconds: UInt64 = 1_000_000_000
+
+/**
+ Class that manages the rotating credentials.
+ */
+public class AwsRotatingCredentialsProviderV2: StoppableCredentialsProvider {
+    public var credentials: Credentials {
+        // the provider returns a copy of the current
+        // credentials which is used within a request.
+        // The provider is then free to rotate credentials
+        // without the risk of rotation causing inconsistent
+        // credentials to be used across a request.
+        return self.statusLock.withLock {
+            return expiringCredentials
+        }
+    }
+
+    private var expiringCredentials: ExpiringCredentials
+
+    let expirationBufferSeconds = 300.0 // 5 minutes
+    let validCredentialsRetrySeconds = 60.0 // 1 minute
+    let invalidCredentialsRetrySeconds = 3600.0 // 1 hour
+
+    let roleSessionName: String?
+    let logger: Logger
+
+    public enum Status {
+        case initialized
+        case running
+        case shuttingDown
+        case stopped
+    }
+
+    public var status: Status
+    let completedSemaphore = DispatchSemaphore(value: 0)
+    var statusLock: NSLock = .init()
+    let expiringCredentialsRetriever: ExpiringCredentialsAsyncRetriever
+
+    /**
+     Initializer that accepts the initial ExpiringCredentials instance for this provider.
+
+     - Parameters:
+        - expiringCredentialsRetriever: retriever of expiring credentials.
+     */
+    @available(swift, deprecated: 3.0, message: "Migrate to async constructor")
+    public init(expiringCredentialsRetriever: ExpiringCredentialsAsyncRetriever,
+                roleSessionName: String?,
+                logger: Logger) throws {
+        self.expiringCredentials = try expiringCredentialsRetriever.get()
+        self.expiringCredentialsRetriever = expiringCredentialsRetriever
+        self.roleSessionName = roleSessionName
+        self.logger = logger
+        self.status = .initialized
+    }
+
+    public init(expiringCredentialsRetriever: ExpiringCredentialsAsyncRetriever,
+                roleSessionName: String?,
+                logger: Logger) async throws {
+        self.expiringCredentials = try await expiringCredentialsRetriever.getCredentials()
+        self.expiringCredentialsRetriever = expiringCredentialsRetriever
+        self.roleSessionName = roleSessionName
+        self.logger = logger
+        self.status = .initialized
+    }
+
+    deinit {
+        try? stop()
+        wait()
+    }
+
+    /**
+     Schedules credentials rotation to begin.
+     */
+    public func start() {
+        self.statusLock.withLock {
+            guard case .initialized = status else {
+                // if this instance isn't in the initialized state, do nothing
+                return
+            }
+
+            // only actually need to start updating credentials if the
+            // initial ones expire
+            if self.expiringCredentials.expiration != nil {
+                Task(priority: .medium) {
+                    await run()
+                }
+
+                self.status = .running
+            }
+        }
+    }
+
+    /**
+     Gracefully shuts down credentials rotation, letting any ongoing work complete..
+     */
+    public func stop() throws {
+        try self.statusLock.withLock {
+            // if there is currently a worker to shutdown
+            switch status {
+                case .initialized:
+                    // no worker ever started, can just go straight to stopped
+                    status = .stopped
+                    try expiringCredentialsRetriever.syncShutdown()
+                    completedSemaphore.signal()
+                case .running:
+                    status = .shuttingDown
+                    try expiringCredentialsRetriever.syncShutdown()
+                default:
+                    // nothing to do
+                    break
+            }
+        }
+    }
+
+    public func shutdown() async throws {
+        let isShutdown = self.statusLock.withLock { () -> Bool in
+            // if there is currently a worker to shutdown
+            switch status {
+                case .initialized:
+                    // no worker ever started, can just go straight to stopped
+                    status = .stopped
+                    completedSemaphore.signal()
+                    return true
+                case .running:
+                    status = .shuttingDown
+                    return true
+                default:
+                    // nothing to do
+                    break
+            }
+
+            return false
+        }
+
+        if isShutdown {
+            try await self.expiringCredentialsRetriever.shutdown()
+        }
+    }
+
+    private func verifyWorkerNotStopped() -> Bool {
+        return self.statusLock.withLock {
+            guard case .stopped = status else {
+                return false
+            }
+
+            return true
+        }
+    }
+
+    /**
+     Waits for the work to exit.
+     If stop() is not called, this will block forever.
+     */
+    public func wait() {
+        guard self.verifyWorkerNotStopped() else {
+            return
+        }
+
+        self.completedSemaphore.wait()
+    }
+
+    private func verifyWorkerNotCancelled() -> Bool {
+        return self.statusLock.withLock {
+            guard case .running = status else {
+                status = .stopped
+                completedSemaphore.signal()
+                return false
+            }
+
+            return true
+        }
+    }
+
+    func run() async {
+        var expiration: Date? = self.expiringCredentials.expiration
+
+        while let currentExpiration = expiration {
+            guard self.verifyWorkerNotCancelled() else {
+                return
+            }
+
+            // create a deadline 5 minutes before the expiration
+            let timeInterval = (currentExpiration - self.expirationBufferSeconds).timeIntervalSinceNow
+            let timeInternalInMinutes = timeInterval / 60
+
+            let minutes = Int(timeInternalInMinutes) % 60
+            let hours = Int(timeInternalInMinutes) / 60
+
+            let logEntryPrefix: String
+            if let roleSessionName = self.roleSessionName {
+                logEntryPrefix = "Credentials for session '\(roleSessionName)'"
+            } else {
+                logEntryPrefix = "Credentials"
+            }
+
+            self.logger.trace(
+                "\(logEntryPrefix) updated; rotation scheduled in \(hours) hours, \(minutes) minutes.")
+            do {
+                try await Task.sleep(nanoseconds: UInt64(timeInterval) * secondsToNanoSeconds)
+            } catch {
+                self.logger.error(
+                    "\(logEntryPrefix) rotation stopped due to error \(error).")
+            }
+
+            expiration = await self.updateCredentials(roleSessionName: roleSessionName, logger: self.logger)
+        }
+    }
+
+    private func updateCredentials(roleSessionName: String?,
+                                   logger _: Logger) async
+    -> Date? {
+        let logEntryPrefix: String
+        if let roleSessionName = roleSessionName {
+            logEntryPrefix = "Credentials for session '\(roleSessionName)'"
+        } else {
+            logEntryPrefix = "Credentials"
+        }
+
+        self.logger.trace("\(logEntryPrefix) about to expire; rotating.")
+
+        let expiration: Date?
+        do {
+            let expiringCredentials = try await self.expiringCredentialsRetriever.getCredentials()
+
+            self.statusLock.withLock {
+                self.expiringCredentials = expiringCredentials
+            }
+
+            expiration = expiringCredentials.expiration
+        } catch {
+            let timeIntervalSinceNow =
+                self.expiringCredentials.expiration?.timeIntervalSinceNow ?? 0
+
+            let retryDuration: Double
+            let logPrefix = "\(logEntryPrefix) rotation failed."
+
+            // if the expiry of the current credentials is still in the future
+            if timeIntervalSinceNow > 0 {
+                // try again relatively soon (still within the 5 minute credentials
+                // expirary buffer) to get new credentials
+                retryDuration = self.validCredentialsRetrySeconds
+
+                self.logger.warning(
+                    "\(logPrefix) Credentials still valid. Attempting credentials refresh in 1 minute.")
+            } else {
+                // at this point, we have tried multiple times to get new credentials
+                // something is quite wrong; try again in the future but at
+                // a reduced frequency
+                retryDuration = self.invalidCredentialsRetrySeconds
+
+                self.logger.error(
+                    "\(logPrefix) Credentials no longer valid. Attempting credentials refresh in 1 hour.")
+            }
+
+            expiration = Date(timeIntervalSinceNow: retryDuration)
+        }
+
+        return expiration
+    }
+}

--- a/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
+++ b/Sources/SmokeAWSCredentials/AwsRotatingCredentialsProviderV2.swift
@@ -22,6 +22,17 @@ import SmokeHTTPClient
 
 private let secondsToNanoSeconds: UInt64 = 1_000_000_000
 
+internal extension NSLocking {
+    func withLock<R>(_ body: () throws -> R) rethrows -> R {
+        self.lock()
+        defer {
+            self.unlock()
+        }
+
+        return try body()
+    }
+}
+
 /**
  Class that manages the rotating credentials.
  */

--- a/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
+++ b/Sources/SmokeAWSCredentials/CredentialsProvider+getAssumedCredentials.swift
@@ -34,6 +34,7 @@ public extension SmokeAWSCore.CredentialsProvider {
         - retryConfiguration: the client retry configuration to use to get the credentials.
                               If not present, the default configuration will be used.
      */
+    @available(swift, deprecated: 3.0, message: "Use async version")
     func getAssumedStaticCredentials(roleArn: String,
                                      roleSessionName: String,
                                      logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
@@ -43,6 +44,17 @@ public extension SmokeAWSCore.CredentialsProvider {
                                                 logger: logger,
                                                 traceContext: AWSClientInvocationTraceContext(),
                                                 retryConfiguration: retryConfiguration)
+    }
+
+    func getAssumedStaticCredentials(roleArn: String,
+                                     roleSessionName: String,
+                                     logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+                                     retryConfiguration: HTTPClientRetryConfiguration = .default) async -> StaticCredentials? {
+        return await self.getAssumedStaticCredentials(roleArn: roleArn,
+                                                      roleSessionName: roleSessionName,
+                                                      logger: logger,
+                                                      traceContext: AWSClientInvocationTraceContext(),
+                                                      retryConfiguration: retryConfiguration)
     }
 
     /**
@@ -56,6 +68,7 @@ public extension SmokeAWSCore.CredentialsProvider {
         - retryConfiguration: the client retry configuration to use to get the credentials.
                               If not present, the default configuration will be used.
      */
+    @available(swift, deprecated: 3.0, message: "Use async version")
     func getAssumedStaticCredentials<TraceContextType: InvocationTraceContext>(roleArn: String,
                                                                                roleSessionName: String,
                                                                                logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
@@ -68,6 +81,25 @@ public extension SmokeAWSCore.CredentialsProvider {
                                                        traceContext: traceContext)
 
         return AWSSecurityTokenClient<CredentialsInvocationReporting<TraceContextType>>.getAssumedStaticCredentials(
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            credentialsProvider: self,
+            reporting: reporting,
+            retryConfiguration: retryConfiguration)
+    }
+
+    func getAssumedStaticCredentials<TraceContextType: InvocationTraceContext>(roleArn: String,
+                                                                               roleSessionName: String,
+                                                                               logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+                                                                               traceContext: TraceContextType,
+                                                                               retryConfiguration: HTTPClientRetryConfiguration = .default) async -> StaticCredentials? {
+        var credentialsLogger = logger
+        credentialsLogger[metadataKey: "credentials.source"] = "assumed.\(roleSessionName)"
+        let reporting = CredentialsInvocationReporting(logger: credentialsLogger,
+                                                       internalRequestId: "credentials.assumed.\(roleSessionName)",
+                                                       traceContext: traceContext)
+
+        return await AWSSecurityTokenClient<CredentialsInvocationReporting<TraceContextType>>.getAssumedStaticCredentials(
             roleArn: roleArn,
             roleSessionName: roleSessionName,
             credentialsProvider: self,
@@ -89,13 +121,30 @@ public extension SmokeAWSCore.CredentialsProvider {
                               If not present, the default configuration will be used.
         - eventLoopProvider: the provider of the event loop for obtaining these credentials.
      */
+    @available(swift, deprecated: 3.0, message: "Use async version")
     func getAssumedRotatingCredentials(roleArn: String,
                                        roleSessionName: String,
                                        durationSeconds: Int?,
                                        logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
                                        retryConfiguration: HTTPClientRetryConfiguration = .default,
-                                       eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew) -> StoppableCredentialsProvider? {
+                                       eventLoopProvider: HTTPClient.EventLoopGroupProvider = .singleton) -> StoppableCredentialsProvider? {
         return self.getAssumedRotatingCredentials(
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            durationSeconds: durationSeconds,
+            logger: logger,
+            traceContext: AWSClientInvocationTraceContext(),
+            retryConfiguration: retryConfiguration,
+            eventLoopProvider: eventLoopProvider)
+    }
+
+    func getAssumedRotatingCredentials(roleArn: String,
+                                       roleSessionName: String,
+                                       durationSeconds: Int?,
+                                       logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+                                       retryConfiguration: HTTPClientRetryConfiguration = .default,
+                                       eventLoopProvider: HTTPClient.EventLoopGroupProvider = .singleton) async -> StoppableCredentialsProvider? {
+        return await self.getAssumedRotatingCredentials(
             roleArn: roleArn,
             roleSessionName: roleSessionName,
             durationSeconds: durationSeconds,
@@ -120,6 +169,7 @@ public extension SmokeAWSCore.CredentialsProvider {
                               If not present, the default configuration will be used.
         - eventLoopProvider: the provider of the event loop for obtaining these credentials.
      */
+    @available(swift, deprecated: 3.0, message: "Use async version")
     func getAssumedRotatingCredentials<TraceContextType: InvocationTraceContext>(roleArn: String,
                                                                                  roleSessionName: String,
                                                                                  durationSeconds: Int?,
@@ -127,7 +177,7 @@ public extension SmokeAWSCore.CredentialsProvider {
                                                                                  traceContext: TraceContextType,
                                                                                  retryConfiguration: HTTPClientRetryConfiguration = .default,
                                                                                  eventLoopProvider: HTTPClient
-                                                                                     .EventLoopGroupProvider = .createNew) -> StoppableCredentialsProvider? {
+                                                                                     .EventLoopGroupProvider = .singleton) -> StoppableCredentialsProvider? {
         var credentialsLogger = logger
         credentialsLogger[metadataKey: "credentials.source"] = "assumed.\(roleSessionName)"
         let reporting = CredentialsInvocationReporting(logger: credentialsLogger,
@@ -135,6 +185,30 @@ public extension SmokeAWSCore.CredentialsProvider {
                                                        traceContext: traceContext)
 
         return AWSSecurityTokenClient<CredentialsInvocationReporting<TraceContextType>>.getAssumedRotatingCredentials(
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            credentialsProvider: self,
+            durationSeconds: durationSeconds,
+            reporting: reporting,
+            retryConfiguration: retryConfiguration,
+            eventLoopProvider: eventLoopProvider)
+    }
+
+    func getAssumedRotatingCredentials<TraceContextType: InvocationTraceContext>(roleArn: String,
+                                                                                 roleSessionName: String,
+                                                                                 durationSeconds: Int?,
+                                                                                 logger: Logging.Logger = Logger(label: "com.amazon.SmokeAWSCredentials"),
+                                                                                 traceContext: TraceContextType,
+                                                                                 retryConfiguration: HTTPClientRetryConfiguration = .default,
+                                                                                 eventLoopProvider: HTTPClient
+                                                                                     .EventLoopGroupProvider = .singleton) async -> StoppableCredentialsProvider? {
+        var credentialsLogger = logger
+        credentialsLogger[metadataKey: "credentials.source"] = "assumed.\(roleSessionName)"
+        let reporting = CredentialsInvocationReporting(logger: credentialsLogger,
+                                                       internalRequestId: "credentials.assumed.\(roleSessionName)",
+                                                       traceContext: traceContext)
+
+        return await AWSSecurityTokenClient<CredentialsInvocationReporting<TraceContextType>>.getAssumedRotatingCredentials(
             roleArn: roleArn,
             roleSessionName: roleSessionName,
             credentialsProvider: self,

--- a/Sources/SmokeAWSCredentials/ExpiringCredentials.swift
+++ b/Sources/SmokeAWSCredentials/ExpiringCredentials.swift
@@ -84,6 +84,16 @@ public struct ExpiringCredentials: Codable, SmokeAWSCore.Credentials {
     static func getCurrentCredentials(dataRetriever: () throws -> Data) throws -> ExpiringCredentials {
         let data = try dataRetriever()
 
+        return try self.getCurrentCredentials(data: data)
+    }
+
+    static func getCurrentCredentials(dataRetriever: () async throws -> Data) async throws -> ExpiringCredentials {
+        let data = try await dataRetriever()
+
+        return try self.getCurrentCredentials(data: data)
+    }
+
+    static func getCurrentCredentials(data: Data) throws -> ExpiringCredentials {
         let expiringCredentials = try jsonDecoder.decode(ExpiringCredentials.self, from: data)
 
         // ensure we are not getting junk credentials data

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import SmokeAWSCredentialsTests
-
-XCTMain([
-    testCase(SmokeAWSCredentialsTests.allTests),
-])

--- a/Tests/SmokeAWSCredentialsTests/TestConfiguration.swift
+++ b/Tests/SmokeAWSCredentialsTests/TestConfiguration.swift
@@ -35,10 +35,13 @@ enum TestVariables {
     static let arn = "ARN"
     static let assumedRoleId = "assumedRoleId"
     static let accessKeyId = "accessKeyId"
+    static let accessKeyId2 = "accessKeyId2"
     static let expiration = "4118-03-12T20:29:09Z"
     static let pastExpiration = "1918-03-12T20:29:09Z"
     static let secretAccessKey = "secretAccessKey"
+    static let secretAccessKey2 = "secretAccessKey2"
     static let sessionToken = "sessionToken"
+    static let sessionToken2 = "sessionToken2"
     static let nullString = "null"
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Migrate to using Swift concurrency tasks to manage credential refreshes. This is handled by the new `AwsRotatingCredentialsProviderV2` type, replacing `AwsRotatingCredentialsProvider` which is retained as it is public
2. use NSLock rather than a raw mutex. Ensure there is sufficient locking around retrieving and updating credentials
3. Add new async versions of the public APIs, deprecating the existing versions. The only difference between the now deprecated versions and the new APIs is that the initial credential retrieval will now be done async - in both cases the subsequent background refreshes will use the Swift-concurrency tasks.
4. Clean-up AwsContainerRotatingCredentialsProvider+get.swift to allow for testing of the code without having to duplicate all functions between async and non-async versions. The exact `AwsRotatingCredentialsProviderV2` initializer that is used is the only difference between the async and non-async versions so this is handled within the initial public functions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
