### PR TITLE
Conform AwsRotatingCredentialsProviderV2 to CredentialsProviderV2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,160 +1,167 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "async-http-client",
-        "repositoryURL": "https://github.com/swift-server/async-http-client.git",
-        "state": {
-          "branch": null,
-          "revision": "16f7e62c08c6969899ce6cc277041e868364e5cf",
-          "version": "1.19.0"
-        }
-      },
-      {
-        "package": "smoke-aws",
-        "repositoryURL": "https://github.com/amzn/smoke-aws.git",
-        "state": {
-          "branch": null,
-          "revision": "35edcb634ac6f6cb25e2bb449acf5f60201c8338",
-          "version": "2.44.298"
-        }
-      },
-      {
-        "package": "smoke-aws-support",
-        "repositoryURL": "https://github.com/amzn/smoke-aws-support.git",
-        "state": {
-          "branch": null,
-          "revision": "4f77513b76d28694dc51dffd0dfd6de6602724a6",
-          "version": "1.3.1"
-        }
-      },
-      {
-        "package": "smoke-http",
-        "repositoryURL": "https://github.com/amzn/smoke-http.git",
-        "state": {
-          "branch": null,
-          "revision": "84e6805ca07f9e4d7c39fbf61b7feff0484ee67f",
-          "version": "2.21.0"
-        }
-      },
-      {
-        "package": "swift-atomics",
-        "repositoryURL": "https://github.com/apple/swift-atomics.git",
-        "state": {
-          "branch": null,
-          "revision": "6c89474e62719ddcc1e9614989fff2f68208fe10",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
-          "version": "1.0.4"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
-          "version": "1.1.7"
-        }
-      },
-      {
-        "package": "swift-distributed-tracing",
-        "repositoryURL": "https://github.com/apple/swift-distributed-tracing.git",
-        "state": {
-          "branch": null,
-          "revision": "49b7617717a09f6b781c9a11e1628e3315d8d4fe",
-          "version": "1.0.1"
-        }
-      },
-      {
-        "package": "swift-log",
-        "repositoryURL": "https://github.com/apple/swift-log.git",
-        "state": {
-          "branch": null,
-          "revision": "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-          "version": "1.5.3"
-        }
-      },
-      {
-        "package": "swift-metrics",
-        "repositoryURL": "https://github.com/apple/swift-metrics.git",
-        "state": {
-          "branch": null,
-          "revision": "971ba26378ab69c43737ee7ba967a896cb74c0d1",
-          "version": "2.4.1"
-        }
-      },
-      {
-        "package": "swift-nio",
-        "repositoryURL": "https://github.com/apple/swift-nio.git",
-        "state": {
-          "branch": null,
-          "revision": "cf281631ff10ec6111f2761052aa81896a83a007",
-          "version": "2.58.0"
-        }
-      },
-      {
-        "package": "swift-nio-extras",
-        "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
-        "state": {
-          "branch": null,
-          "revision": "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
-          "version": "1.19.0"
-        }
-      },
-      {
-        "package": "swift-nio-http2",
-        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
-        "state": {
-          "branch": null,
-          "revision": "a8ccf13fa62775277a5d56844878c828bbb3be1a",
-          "version": "1.27.0"
-        }
-      },
-      {
-        "package": "swift-nio-ssl",
-        "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
-        "state": {
-          "branch": null,
-          "revision": "320bd978cceb8e88c125dcbb774943a92f6286e9",
-          "version": "2.25.0"
-        }
-      },
-      {
-        "package": "swift-nio-transport-services",
-        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
-        "state": {
-          "branch": null,
-          "revision": "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
-          "version": "1.19.0"
-        }
-      },
-      {
-        "package": "swift-service-context",
-        "repositoryURL": "https://github.com/apple/swift-service-context.git",
-        "state": {
-          "branch": null,
-          "revision": "ce0141c8f123132dbd02fd45fea448018762df1b",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "XMLCoding",
-        "repositoryURL": "https://github.com/LiveUI/XMLCoding.git",
-        "state": {
-          "branch": null,
-          "revision": "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
-          "version": "0.4.1"
-        }
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "16f7e62c08c6969899ce6cc277041e868364e5cf",
+        "version" : "1.19.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "smoke-aws",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/smoke-aws.git",
+      "state" : {
+        "revision" : "07e658e0fdc8a46923156c30a76fdd5d7427465e",
+        "version" : "2.46.5"
+      }
+    },
+    {
+      "identity" : "smoke-aws-support",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/smoke-aws-support.git",
+      "state" : {
+        "revision" : "141efadb31e399736b23cfd2478af3dbdc170259",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "smoke-http",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amzn/smoke-http.git",
+      "state" : {
+        "revision" : "2f27d29b863c797f74318f87579bac77935df2eb",
+        "version" : "2.22.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "49b7617717a09f6b781c9a11e1628e3315d8d4fe",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "99d066e29effa8845e4761dd3f2f831edfdf8925",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
+        "version" : "1.5.3"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "971ba26378ab69c43737ee7ba967a896cb74c0d1",
+        "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
+        "version" : "2.62.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "798c962495593a23fdea0c0c63fd55571d8dff51",
+        "version" : "1.20.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "3bd9004b9d685ed6b629760fc84903e48efec806",
+        "version" : "1.29.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "320bd978cceb8e88c125dcbb774943a92f6286e9",
+        "version" : "2.25.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "ebf8b9c365a6ce043bf6e6326a04b15589bd285e",
+        "version" : "1.20.0"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "ce0141c8f123132dbd02fd45fea448018762df1b",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "xmlcoding",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/LiveUI/XMLCoding.git",
+      "state" : {
+        "revision" : "f0fbfe17e73f329e13a6133ff5437f7b174049fd",
+        "version" : "0.4.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -28,12 +28,14 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/amzn/smoke-aws.git", from: "2.44.174"),
+        .package(url: "https://github.com/amzn/smoke-aws-support.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "SmokeAWSCredentials", dependencies: [
+                .product(name: "AWSCore", package: "smoke-aws-support"),
                 .product(name: "SecurityTokenClient", package: "smoke-aws"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIO", package: "swift-nio"),

--- a/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderV2Tests.swift
+++ b/Tests/SmokeAWSCredentialsTests/AwsRotatingCredentialsProviderV2Tests.swift
@@ -1,0 +1,314 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  AwsContainerRotatingCredentialsV2Tests.swift
+//  SmokeAWSCredentials
+//
+
+import Logging
+@testable import SmokeAWSCredentials
+import SmokeHTTPClient
+import XCTest
+import Logging
+import SmokeAWSCore
+
+private enum TestErrors: Swift.Error {
+    case retrieverError
+}
+
+private actor TestExpiringCredentialsAsyncRetriever: ExpiringCredentialsAsyncRetriever {
+    enum Result {
+        case credentials(SmokeAWSCredentials.ExpiringCredentials)
+        case error(Swift.Error)
+    }
+    var results: [Result]
+    
+    init(results: [Result]) {
+        self.results = results.reversed()
+    }
+    func getCredentials() async throws -> SmokeAWSCredentials.ExpiringCredentials {
+        let result = self.results.popLast()!
+        
+        switch result {
+        case .credentials(let expiringCredentials):
+            return expiringCredentials
+        case .error(let error):
+            throw error
+        }
+    }
+    
+    nonisolated func close() throws {
+        // nothing to do
+    }
+    
+    func shutdown() async throws {
+        // nothing to do
+    }
+    nonisolated func get() throws -> SmokeAWSCredentials.ExpiringCredentials {
+        fatalError("Not implemented")
+    }
+    
+    
+}
+
+class AwsContainerRotatingCredentialsV2Tests: XCTestCase {
+    private let accessKeyId1 = "accessKeyId1"
+    private let accessKeyId2 = "accessKeyId2"
+    private let accessKeyId3 = "accessKeyId3"
+    private let secretAccessKey1 = "secretAccessKey1"
+    private let secretAccessKey2 = "secretAccessKey2"
+    private let secretAccessKey3 = "secretAccessKey3"
+    private let sessionToken1 = "sessionToken1"
+    private let sessionToken2 = "sessionToken2"
+    private let sessionToken3 = "sessionToken3"
+    
+    func testBackgroundRefresh() async throws {
+        let firstCredentials = SmokeAWSCredentials.ExpiringCredentials(accessKeyId: accessKeyId1,
+                                                                       expiration: Date() + 10,
+                                                                       secretAccessKey: secretAccessKey1,
+                                                                       sessionToken: sessionToken1)
+        let secondCredentials = SmokeAWSCredentials.ExpiringCredentials(accessKeyId: accessKeyId2,
+                                                                       expiration: Date() + 20,
+                                                                       secretAccessKey: secretAccessKey2,
+                                                                       sessionToken: sessionToken2)
+        let thirdCredentials = SmokeAWSCredentials.ExpiringCredentials(accessKeyId: accessKeyId3,
+                                                                       expiration: Date() + 3600,
+                                                                       secretAccessKey: secretAccessKey3,
+                                                                       sessionToken: sessionToken3)
+        
+        let retriever = TestExpiringCredentialsAsyncRetriever(results: [.credentials(firstCredentials),
+                                                                        .credentials(secondCredentials),
+                                                                        .credentials(thirdCredentials)])
+        let provider = try await AwsRotatingCredentialsProviderV2(
+            expiringCredentialsRetriever: retriever,
+            roleSessionName: nil,
+            logger: Logger(label: "test.logger"),
+            expirationBufferSeconds: 2,
+            backgroundExpirationBufferSeconds: 5)
+        
+        provider.start()
+        
+        // will return credentials retrieved from the first time the credentials are called
+        let retrievedCredentials1 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials1.accessKeyId, firstCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials1.secretAccessKey, firstCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials1.sessionToken, firstCredentials.sessionToken)
+        
+        
+        // legacy property should match
+        let retrievedCredentials1_1 = provider.credentials
+        XCTAssertEqual(retrievedCredentials1_1.accessKeyId, firstCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials1_1.secretAccessKey, firstCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials1_1.sessionToken, firstCredentials.sessionToken)
+        
+        // the background credentials refresh should happen after 5 seconds (five seconds before the expiration)
+        try await Task.sleep(for: .seconds(6))
+        
+        // will return credentials retrieved from the background refresh
+        // even through the first credentials haven't expired yet
+        let retrievedCredentials2 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials2.accessKeyId, secondCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials2.secretAccessKey, secondCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials2.sessionToken, secondCredentials.sessionToken)
+        
+        // legacy property should match
+        let retrievedCredentials2_1 = provider.credentials
+        XCTAssertEqual(retrievedCredentials2_1.accessKeyId, secondCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials2_1.secretAccessKey, secondCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials2_1.sessionToken, secondCredentials.sessionToken)
+        
+        // sleep until after the first credentials have expired
+        try await Task.sleep(for: .seconds(6))
+        
+        // should still be the second credentials
+        let retrievedCredentials3 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials3.accessKeyId, secondCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials3.secretAccessKey, secondCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials3.sessionToken, secondCredentials.sessionToken)
+        
+        // legacy property should match
+        let retrievedCredentials3_1 = provider.credentials
+        XCTAssertEqual(retrievedCredentials3_1.accessKeyId, secondCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials3_1.secretAccessKey, secondCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials3_1.sessionToken, secondCredentials.sessionToken)
+        
+        // the next background credentials refresh should happen after 15 seconds (five seconds before the expiration)
+        try await Task.sleep(for: .seconds(4))
+        
+        // will return credentials retrieved from the second background refresh
+        // even through the second credentials haven't expired yet
+        let retrievedCredentials4 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials4.accessKeyId, thirdCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials4.secretAccessKey, thirdCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials4.sessionToken, thirdCredentials.sessionToken)
+        
+        // legacy property should match
+        let retrievedCredentials4_1 = provider.credentials
+        XCTAssertEqual(retrievedCredentials4_1.accessKeyId, thirdCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials4_1.secretAccessKey, thirdCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials4_1.sessionToken, thirdCredentials.sessionToken)
+        
+        // sleep until after the second credentials have expired
+        try await Task.sleep(for: .seconds(6))
+        
+        // should still be the third credentials
+        let retrievedCredentials5 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials5.accessKeyId, thirdCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials5.secretAccessKey, thirdCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials5.sessionToken, thirdCredentials.sessionToken)
+        
+        // legacy property should match
+        let retrievedCredentials5_1 = provider.credentials
+        XCTAssertEqual(retrievedCredentials5_1.accessKeyId, thirdCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials5_1.secretAccessKey, thirdCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials5_1.sessionToken, thirdCredentials.sessionToken)
+        
+        try await provider.shutdown()
+        provider.wait()
+    }
+    
+    func testFailedBackgroundRefresh() async throws {
+        let firstCredentials = SmokeAWSCredentials.ExpiringCredentials(accessKeyId: accessKeyId1,
+                                                                       expiration: Date() + 10,
+                                                                       secretAccessKey: secretAccessKey1,
+                                                                       sessionToken: sessionToken1)
+        let secondCredentials = SmokeAWSCredentials.ExpiringCredentials(accessKeyId: accessKeyId2,
+                                                                       expiration: Date() + 20,
+                                                                       secretAccessKey: secretAccessKey2,
+                                                                       sessionToken: sessionToken2)
+        let thirdCredentials = SmokeAWSCredentials.ExpiringCredentials(accessKeyId: accessKeyId3,
+                                                                       expiration: Date() + 3600,
+                                                                       secretAccessKey: secretAccessKey3,
+                                                                       sessionToken: sessionToken3)
+        
+        let retriever = TestExpiringCredentialsAsyncRetriever(results: [.credentials(firstCredentials),
+                                                                        .error(TestErrors.retrieverError),
+                                                                        .credentials(secondCredentials),
+                                                                        .credentials(thirdCredentials)])
+        let provider = try await AwsRotatingCredentialsProviderV2(
+            expiringCredentialsRetriever: retriever,
+            roleSessionName: nil,
+            logger: Logger(label: "test.logger"),
+            expirationBufferSeconds: 2,
+            backgroundExpirationBufferSeconds: 5)
+        
+        provider.start()
+        
+        // will return credentials retrieved from the first time the credentials are called
+        let retrievedCredentials1 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials1.accessKeyId, firstCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials1.secretAccessKey, firstCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials1.sessionToken, firstCredentials.sessionToken)
+        
+        // the background credentials refresh should happen after 5 seconds (five seconds before the expiration)
+        try await Task.sleep(for: .seconds(6))
+        
+        // will return the first credentials as the background refresh failed
+        // and not within expirationBufferSeconds of the credentials expiry
+        let retrievedCredentials2 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials2.accessKeyId, firstCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials2.secretAccessKey, firstCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials2.sessionToken, firstCredentials.sessionToken)
+        
+        // sleep to within the expirationBufferSeconds
+        try await Task.sleep(for: .seconds(3))
+        
+        // will actually go and retrieve refreshed credentials
+        let retrievedCredentials2_2 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials2_2.accessKeyId, secondCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials2_2.secretAccessKey, secondCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials2_2.sessionToken, secondCredentials.sessionToken)
+        
+        // sleep until after the first credentials have expired
+        try await Task.sleep(for: .seconds(3))
+        
+        // should still be the second credentials
+        let retrievedCredentials3 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials3.accessKeyId, secondCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials3.secretAccessKey, secondCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials3.sessionToken, secondCredentials.sessionToken)
+        
+        // the next background credentials refresh should happen after 15 seconds (five seconds before the expiration)
+        // the failure of the first background refresh shound not impact this occurring
+        try await Task.sleep(for: .seconds(4))
+        
+        // will return credentials retrieved from the second background refresh
+        // even through the second credentials haven't expired yet
+        let retrievedCredentials4 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials4.accessKeyId, thirdCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials4.secretAccessKey, thirdCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials4.sessionToken, thirdCredentials.sessionToken)
+        
+        // sleep until after the second credentials have expired
+        try await Task.sleep(for: .seconds(6))
+        
+        // should still be the third credentials
+        let retrievedCredentials5 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials5.accessKeyId, thirdCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials5.secretAccessKey, thirdCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials5.sessionToken, thirdCredentials.sessionToken)
+        
+        try await provider.shutdown()
+        provider.wait()
+    }
+    
+    func testFailedRetrieval() async throws {
+        let firstCredentials = SmokeAWSCredentials.ExpiringCredentials(accessKeyId: accessKeyId1,
+                                                                       expiration: Date() + 10,
+                                                                       secretAccessKey: secretAccessKey1,
+                                                                       sessionToken: sessionToken1)
+        
+        let retriever = TestExpiringCredentialsAsyncRetriever(results: [.credentials(firstCredentials),
+                                                                        .error(TestErrors.retrieverError),
+                                                                        .error(TestErrors.retrieverError)])
+        let provider = try await AwsRotatingCredentialsProviderV2(
+            expiringCredentialsRetriever: retriever,
+            roleSessionName: nil,
+            logger: Logger(label: "test.logger"),
+            expirationBufferSeconds: 2,
+            backgroundExpirationBufferSeconds: 5)
+        
+        provider.start()
+        
+        // will return credentials retrieved from the first time the credentials are called
+        let retrievedCredentials1 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials1.accessKeyId, firstCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials1.secretAccessKey, firstCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials1.sessionToken, firstCredentials.sessionToken)
+        
+        // the background credentials refresh should happen after 5 seconds (five seconds before the expiration)
+        try await Task.sleep(for: .seconds(6))
+        
+        // will return the first credentials as the background refresh failed
+        // and not within expirationBufferSeconds of the credentials expiry
+        let retrievedCredentials2 = try await provider.getCredentials()
+        XCTAssertEqual(retrievedCredentials2.accessKeyId, firstCredentials.accessKeyId)
+        XCTAssertEqual(retrievedCredentials2.secretAccessKey, firstCredentials.secretAccessKey)
+        XCTAssertEqual(retrievedCredentials2.sessionToken, firstCredentials.sessionToken)
+        
+        // sleep to within the expirationBufferSeconds
+        try await Task.sleep(for: .seconds(3))
+        
+        // will actually go and retrieve refreshed credentials
+        do {
+            _ = try await provider.getCredentials()
+            
+            XCTFail("Expected error not thrown")
+        } catch TestErrors.retrieverError {
+            // expected error
+        }
+        
+        try await provider.shutdown()
+        provider.wait()
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Conform AwsRotatingCredentialsProviderV2 to CredentialsProviderV2. Use an actor to manage state and refresh credentials on demand if required.

Added unit tests to verify the main use cases for AwsRotatingCredentialsProviderV2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.